### PR TITLE
(master) Updates captor abort/reset behaviors

### DIFF
--- a/flow/include/impl/captor_nolock.hpp
+++ b/flow/include/impl/captor_nolock.hpp
@@ -67,7 +67,11 @@ private:
    */
   inline void reset_impl()
   {
+    // Run reset behavior specific to this captor
     derived()->reset_policy_impl();
+
+    // Remove all data
+    CaptorInterfaceType::queue_.clear();
   }
 
   /**
@@ -75,6 +79,7 @@ private:
    */
   inline void abort_impl(const stamp_type& t_abort)
   {
+    // Run abort behavior specific to this captor
     derived()->abort_policy_impl(t_abort);
   }
 

--- a/flow/include/impl/captor_polling.hpp
+++ b/flow/include/impl/captor_polling.hpp
@@ -70,7 +70,12 @@ private:
   inline void reset_impl()
   {
     BasicLockableT lock{queue_mutex_};
+
+    // Run reset behavior specific to this captor
     derived()->reset_policy_impl();
+
+    // Remove all data
+    CaptorInterfaceType::queue_.clear();
   }
 
   /**
@@ -79,6 +84,8 @@ private:
   inline void abort_impl(const stamp_type& t_abort)
   {
     BasicLockableT lock{queue_mutex_};
+
+    // Run abort behavior specific to this captor
     derived()->abort_policy_impl(t_abort);
   }
 

--- a/flow/include/synchronizer.h
+++ b/flow/include/synchronizer.h
@@ -127,7 +127,8 @@ public:
   template<typename CaptorTupleT, typename OutputIteratorTupleT>
   static result_t<CaptorTupleT> capture(CaptorTupleT&& captors,
                                         OutputIteratorTupleT&& outputs,
-                                        const stamp_arg_t<CaptorTupleT> lower_bound);
+                                        const stamp_arg_t<CaptorTupleT> lower_bound =
+                                          StampTraits<stamp_t<CaptorTupleT>>::min());
 
   /**
    * @brief Runs event input capture dry-run

--- a/flow/test/unit/synchronizer.cpp
+++ b/flow/test/unit/synchronizer.cpp
@@ -5,12 +5,12 @@
 #ifndef DOXYGEN_SKIP
 
 // C++ Standard Library
-#include <chrono>
+#include <deque>
+#include <list>
 #include <iterator>
-#include <memory>
-#include <queue>
-#include <string>
-#include <thread>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 // GTest
 #include <gtest/gtest.h>
@@ -160,5 +160,191 @@ TEST_F(SynchronizerTestSuite, DryCaptureCanPrime)
   ASSERT_EQ(result.state, State::PRIMED);
 }
 
+
+// Type we will use to as a data sequencing stamp
+using sequencing_type = int;
+
+
+// Sequencing stamp + data
+template<typename T>
+using MyDispatch = Dispatch<sequencing_type, T>;
+
+
+TEST(Synchronizer, UsageExampleExampleSingleThreaded)
+{
+  using namespace flow;
+
+  // Type aliases for captors
+  using NextType = driver::Next<MyDispatch<int>, NoLock>;
+  using ClosestType = follower::ClosestBefore<MyDispatch<double>, NoLock>;
+  using BeforeType = follower::Before<MyDispatch<std::string>, NoLock>;
+
+  // Setup driving captor
+  NextType next_driver;
+
+  // Setup first following input captor
+  ClosestType closest_follower{1 /*period*/, 0 /*delay offset*/};
+
+  // Setup second following input captor
+  BeforeType before_follower{1 /*delay offset*/};
+
+  // Add some data
+  for (int n = 0; n < 20; ++n)
+  {
+    next_driver.inject(n, n);
+    closest_follower.inject(n-2, static_cast<double>(n) + 0.1234);
+    before_follower.inject(n-4, "flow" + std::to_string(n));
+  }
+ 
+  static constexpr std::size_t EXPECTED_SYNC_COUNT = 17;
+  std::size_t sync_count = 0;
+
+  // Synchronize
+  bool working = true;
+  while (working)
+  {
+    // Any iterable container can be used to capture data (even raw buffers!). Capturing through
+    // iterators allows the end user to specify their own memory handling
+    std::vector<MyDispatch<int>> next_driver_data;
+    std::list<MyDispatch<double>> closest_follower_data;
+    std::deque<MyDispatch<std::string>> before_follower_data;
+
+    // Run data capture
+    const auto result = Synchronizer::capture(
+      std::forward_as_tuple(next_driver, closest_follower, before_follower),
+      std::forward_as_tuple(std::back_inserter(next_driver_data),
+                            std::back_inserter(closest_follower_data),
+                            std::back_inserter(before_follower_data)));
+
+    switch (result.state)
+    {
+      case State::PRIMED:
+        // do stuff with synchronized data
+        ++sync_count;
+        break;
+      case State::ABORT:
+        // could not synchronize with current data
+        break;
+      case State::RETRY:
+        // need newer data to synchronize
+        working = false;
+        break;
+      case State::TIMEOUT: // multithreading only
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Start a clean slate, if you need to
+  Synchronizer::reset(std::forward_as_tuple(next_driver, closest_follower, before_follower));
+
+  ASSERT_EQ(next_driver.size(), 0UL);
+  ASSERT_EQ(closest_follower.size(), 0UL);
+  ASSERT_EQ(before_follower.size(), 0UL);
+
+  ASSERT_EQ(sync_count, EXPECTED_SYNC_COUNT);
+}
+
+
+// Flow + Multithreading
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+TEST(Synchronizer, UsageExampleExampleMultiThreaded)
+{
+  using namespace flow;
+
+  // Type aliases for captors
+  using NextType = driver::Next<MyDispatch<int>, std::unique_lock<std::mutex>>;
+  using ClosestType = follower::ClosestBefore<MyDispatch<double>, std::unique_lock<std::mutex>>;
+  using BeforeType = follower::Before<MyDispatch<std::string>, std::unique_lock<std::mutex>>;
+
+  // Setup driving captor
+  NextType next_driver;
+
+  // Setup first following input captor
+  ClosestType closest_follower{1 /*period*/, 0 /*delay offset*/};
+
+  // Setup second following input captor
+  BeforeType before_follower{1 /*delay offset*/};
+
+  std::mutex progress_mutex;
+  std::condition_variable progress_cv;
+
+  static constexpr std::size_t EXPECTED_SYNC_COUNT = 17;
+  std::size_t sync_count = 0;
+
+  // Synchronize
+  std::thread synchronizer_thread{
+    [&]
+    {
+      bool working = true;
+      while (working)
+      {
+        // Any iterable container can be used to capture data (even raw buffers!). Capturing through
+        // iterators allows the end user to specify their own memory handling
+        std::vector<MyDispatch<int>> next_driver_data;
+        std::list<MyDispatch<double>> closest_follower_data;
+        std::deque<MyDispatch<std::string>> before_follower_data;
+
+        // Run data capture
+        const auto result = Synchronizer::capture(
+          std::forward_as_tuple(next_driver, closest_follower, before_follower),
+          std::forward_as_tuple(std::back_inserter(next_driver_data),
+                                std::back_inserter(closest_follower_data),
+                                std::back_inserter(before_follower_data)));
+
+        switch (result.state)
+        {
+          case State::PRIMED:
+            // do stuff with synchronized data
+            ++sync_count;
+            if (sync_count == EXPECTED_SYNC_COUNT)
+            {
+              progress_cv.notify_one();
+              working = false;
+            }
+            break;
+          case State::ABORT:
+            // could not synchronize with current data
+            // normally we could keep working, but we want the test to end
+            break;
+          case State::RETRY: // polling-mode only
+            break;
+          case State::TIMEOUT:
+            break;
+          default:
+            break;
+        }
+      }
+      progress_cv.notify_all();
+    }
+  };
+
+  // Add some data
+  for (int n = 0; n < 20; ++n)
+  {
+    next_driver.inject(n, n);
+    closest_follower.inject(n-2, static_cast<double>(n) + 0.1234);
+    before_follower.inject(n-4, "flow" + std::to_string(n));
+  }
+
+  // Wait for sync pogress
+  std::unique_lock<std::mutex> lock{progress_mutex};
+  progress_cv.wait(lock);
+
+  // Cancel all data-waits; start a clean slate, if you need to
+  Synchronizer::reset(std::forward_as_tuple(next_driver, closest_follower, before_follower));
+
+  synchronizer_thread.join();
+
+  ASSERT_EQ(next_driver.size(), 0UL);
+  ASSERT_EQ(closest_follower.size(), 0UL);
+  ASSERT_EQ(before_follower.size(), 0UL);
+
+  ASSERT_EQ(sync_count, EXPECTED_SYNC_COUNT);
+}
 
 #endif  // DOXYGEN_SKIP


### PR DESCRIPTION
- Updates abort behavior to work when called externally
    + Should work when called at any point in execution
- Updates reset behavior for none MT captor implementations
- Adds extra "full-example" tests