### PR TITLE
(master) Switch to non-member stamp/value accessors

### DIFF
--- a/flow/include/dispatch.h
+++ b/flow/include/dispatch.h
@@ -82,10 +82,7 @@ template <typename ClockT, typename DurationT> struct StampTraits<std::chrono::t
  * @brief Dispatch data wrapper
  *
  *        Custom "dispatching" objects may be used with this library in lieu of
- *        the standard <code>Dispatch</code> template provided in this file, so
- *        long as they implement the following methods:
- *        - <code>DispatchT::stamp()</code>: returns data sequencing stamp
- *        - <code>DispatchT::data()</code>: returns an immutable reference to the data itself
+ *        the standard <code>Dispatch</code> template provided in this file
  * \n
  *        Custom dispatch types must also specialize the <code>DispatchTraits</code> helper
  *        struct, which is used to provide core <code>stamp_type</code> and <code>value_type</code>
@@ -103,50 +100,44 @@ public:
    * @brief Dispatch value constructor (move enabled)
    */
   template <typename... ValueArgsTs>
-  explicit Dispatch(const StampT& stamp, ValueArgsTs&&... value_args) :
-      stamp_{stamp},
-      value_{std::forward<ValueArgsTs>(value_args)...}
+  explicit Dispatch(const StampT& _stamp, ValueArgsTs&&... _value_args) :
+      stamp{_stamp},
+      value{std::forward<ValueArgsTs>(_value_args)...}
   {}
 
-  /**
-   * @brief Returns sequencing stamp associated with data element
-   */
-  inline const StampT& stamp() const { return stamp_; }
-
-  /**
-   * @brief Returns const reference to underlying data element
-   */
-  inline const ValueT& data() const { return value_; }
-
-private:
   /// Sequencing stamp associated with data
-  StampT stamp_;
+  StampT stamp;
 
   /// Data element
-  ValueT value_;
-
-  /**
-   * @brief Output stream overload for <code>Dispatch</code> codes
-   * @param[in,out] os  output stream
-   * @param dispatch  dispatch object
-   * @return os
-   */
-  friend inline std::ostream& operator<<(std::ostream& os, const Dispatch& dispatch)
-  {
-    return os << "stamp: " << dispatch.stamp_ << "\nvalue: " << dispatch.value_;
-  }
+  ValueT value;
 };
+
+
+/**
+ * @brief Output stream overload for <code>Dispatch</code> codes
+ * @param[in,out] os  output stream
+ * @param dispatch  dispatch object
+ * @return os
+ */
+template <typename StampT, typename ValueT>
+inline std::ostream& operator<<(std::ostream& os, const Dispatch<StampT, ValueT>& dispatch)
+{
+  return os << "stamp: " << dispatch.stamp << "\nvalue: " << dispatch.value;
+}
 
 
 /**
  * @brief Dispatch type traits struct
  */
-template <typename DispatchT>
-struct DispatchTraits
-#ifndef DOXYGEN_SKIP
-  ;
+template <typename DispatchT> struct DispatchTraits;
+
+
+/**
+ * @copydoc DispatchTraits
+ *
+ * @note partial specialization for Dispatch
+ */
 template <typename StampT, typename ValueT> struct DispatchTraits<Dispatch<StampT, ValueT>>
-#endif  // DOXYGEN_SKIP
 {
   /// Dispatch stamp type
   using stamp_type = StampT;
@@ -154,6 +145,79 @@ template <typename StampT, typename ValueT> struct DispatchTraits<Dispatch<Stamp
   /// Dispatch data type
   using value_type = ValueT;
 };
+
+
+/**
+ * @copydoc DispatchTraits
+ *
+ * @note partial specialization for <code>::std::pair</code>
+ */
+template <typename StampT, typename ValueT> struct DispatchTraits<::std::pair<StampT, ValueT>>
+{
+  /// Dispatch stamp type
+  using stamp_type = StampT;
+
+  /// Dispatch data type
+  using value_type = ValueT;
+};
+
+
+/**
+ * @brief Dispatch access helper
+ */
+template <typename DispatchT> struct DispatchAccess;
+
+
+/**
+ * @copydoc DispatchAccess
+ *
+ * @note partial specialization for Dispatch
+ */
+template <typename StampT, typename ValueT> struct DispatchAccess<Dispatch<StampT, ValueT>>
+{
+  /// Selects type of lesser size to use when returning values
+  template <typename T> using return_t = std::conditional_t<(sizeof(T) <= sizeof(T&)), T, const T&>;
+
+  static constexpr return_t<StampT> stamp(const Dispatch<StampT, ValueT>& dispatch) { return dispatch.stamp; }
+
+  static constexpr return_t<ValueT> value(const Dispatch<StampT, ValueT>& dispatch) { return dispatch.value; }
+};
+
+
+/**
+ * @copydoc DispatchAccess
+ *
+ * @note partial specialization for <code>::std::pair</code>
+ */
+template <typename StampT, typename ValueT> struct DispatchAccess<::std::pair<StampT, ValueT>>
+{
+  /// Selects type of lesser size to use when returning values
+  template <typename T> using return_t = std::conditional_t<(sizeof(T) <= sizeof(T&)), T, const T&>;
+
+  static constexpr return_t<StampT> stamp(const ::std::pair<StampT, ValueT>& dispatch) { return dispatch.first; }
+
+  static constexpr return_t<ValueT> value(const ::std::pair<StampT, ValueT>& dispatch) { return dispatch.second; }
+};
+
+
+/**
+ * @brief Accesses Dispatch stamp through appropriate accessors
+ */
+template <typename DispatchT> constexpr auto get_stamp(DispatchT&& dispatch)
+{
+  using D = std::remove_const_t<std::remove_reference_t<DispatchT>>;
+  return DispatchAccess<D>::stamp(std::forward<DispatchT>(dispatch));
+}
+
+
+/**
+ * @brief Accesses Dispatch value through appropriate accessors
+ */
+template <typename DispatchT> constexpr auto get_value(DispatchT&& dispatch)
+{
+  using D = std::remove_const_t<std::remove_reference_t<DispatchT>>;
+  return DispatchAccess<D>::value(std::forward<DispatchT>(dispatch));
+}
 
 
 /**
@@ -194,19 +258,20 @@ template <typename StampT> struct CaptureRange
    * @copydoc CaptureRange::valid
    */
   inline operator bool() const { return valid(); }
-
-  /**
-   * @brief Output stream overload for <code>CaptureRange</code> codes
-   *
-   * @param[in,out] os  output stream
-   * @param range  capture stamp range
-   * @return os
-   */
-  friend inline std::ostream& operator<<(std::ostream& os, const CaptureRange& range)
-  {
-    return os << "lower_stamp: " << range.lower_stamp << ", upper_stamp: " << range.upper_stamp;
-  }
 };
+
+
+/**
+ * @brief Output stream overload for <code>CaptureRange</code> codes
+ *
+ * @param[in,out] os  output stream
+ * @param range  capture stamp range
+ * @return os
+ */
+template <typename StampT> inline std::ostream& operator<<(std::ostream& os, const CaptureRange<StampT>& range)
+{
+  return os << "lower_stamp: " << range.lower_stamp << ", upper_stamp: " << range.upper_stamp;
+}
 
 }  // namespace flow
 

--- a/flow/include/dispatch_queue.h
+++ b/flow/include/dispatch_queue.h
@@ -110,7 +110,7 @@ public:
    *
    * @warning Undefined behavior when <code>empty() == true</code>
    */
-  inline stamp_type oldest_stamp() const { return queue_.front().stamp(); }
+  inline stamp_type oldest_stamp() const { return get_stamp(queue_.front()); }
 
   /**
    * @brief Sequencing stamp associated with the newest data
@@ -118,7 +118,7 @@ public:
    *
    * @warning Undefined behavior when <code>empty() == true</code>
    */
-  inline stamp_type newest_stamp() const { return queue_.back().stamp(); }
+  inline stamp_type newest_stamp() const { return get_stamp(queue_.back()); }
 
   /**
    * @brief Removes the oldest element and returns associated Dispatch

--- a/flow/include/driver/impl/batch.hpp
+++ b/flow/include/driver/impl/batch.hpp
@@ -71,8 +71,8 @@ State Batch<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(Capture
   {
     auto oldest_itr = PolicyType::queue_.begin();
 
-    range.lower_stamp = oldest_itr->stamp();
-    range.upper_stamp = std::next(oldest_itr, batch_size_ - 1)->stamp();
+    range.lower_stamp = get_stamp(*oldest_itr);
+    range.upper_stamp = get_stamp(*std::next(oldest_itr, batch_size_ - 1));
 
     return State::PRIMED;
   }

--- a/flow/include/driver/impl/chunk.hpp
+++ b/flow/include/driver/impl/chunk.hpp
@@ -74,8 +74,8 @@ State Chunk<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(Capture
   {
     auto oldest_itr = PolicyType::queue_.begin();
 
-    range.lower_stamp = oldest_itr->stamp();
-    range.upper_stamp = std::next(oldest_itr, chunk_size_ - 1)->stamp();
+    range.lower_stamp = get_stamp(*oldest_itr);
+    range.upper_stamp = get_stamp(*std::next(oldest_itr, chunk_size_ - 1));
 
     return State::PRIMED;
   }

--- a/flow/include/driver/impl/throttled.hpp
+++ b/flow/include/driver/impl/throttled.hpp
@@ -73,9 +73,10 @@ State Throttled<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(Cap
 {
   for (const auto& dispatch : PolicyType::queue_)
   {
-    if (previous_stamp_ == StampTraits<stamp_type>::min() or (dispatch.stamp() - previous_stamp_) >= throttle_period_)
+    if (
+      previous_stamp_ == StampTraits<stamp_type>::min() or (get_stamp(dispatch) - previous_stamp_) >= throttle_period_)
     {
-      range.lower_stamp = dispatch.stamp();
+      range.lower_stamp = get_stamp(dispatch);
       range.upper_stamp = range.lower_stamp;
 
       return State::PRIMED;

--- a/flow/include/follower/impl/closest_before.hpp
+++ b/flow/include/follower/impl/closest_before.hpp
@@ -71,12 +71,12 @@ State ClosestBefore<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_im
   auto capture_itr = PolicyType::queue_.end();
   for (auto itr = PolicyType::queue_.begin(); itr != PolicyType::queue_.end(); ++itr)
   {
-    if (itr->stamp() >= boundary)
+    if (get_stamp(*itr) >= boundary)
     {
       // If oldest element is far ahead of boundary, abort
       return State::ABORT;
     }
-    else if (itr->stamp() + period_ >= boundary)
+    else if (get_stamp(*itr) + period_ >= boundary)
     {
       // If oldest element is first within period, collect
       capture_itr = itr;
@@ -88,7 +88,7 @@ State ClosestBefore<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_im
   // NOTE: If no capture input was set, then all data is at or after boundary
   if (capture_itr != PolicyType::queue_.end())
   {
-    PolicyType::queue_.remove_before(capture_itr->stamp());
+    PolicyType::queue_.remove_before(get_stamp(*capture_itr));
     return State::PRIMED;
   }
   else

--- a/flow/include/follower/impl/count_before.hpp
+++ b/flow/include/follower/impl/count_before.hpp
@@ -89,7 +89,7 @@ State CountBefore<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl
   // Scroll to element boundary
   size_type before_boundary_count = 0;
   auto itr = PolicyType::queue_.begin();
-  while (itr != PolicyType::queue_.end() and boundary > itr->stamp())
+  while (itr != PolicyType::queue_.end() and boundary > get_stamp(*itr))
   {
     ++before_boundary_count;
     ++itr;
@@ -101,7 +101,7 @@ State CountBefore<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl
   if (before_boundary_count >= count_)
   {
     const auto first_itr = std::prev(itr, count_);
-    PolicyType::queue_.remove_before(first_itr->stamp());
+    PolicyType::queue_.remove_before(get_stamp(*first_itr));
     return State::PRIMED;
   }
   else if (at_or_after_boundary_count)

--- a/flow/include/follower/impl/latched.hpp
+++ b/flow/include/follower/impl/latched.hpp
@@ -97,7 +97,7 @@ State Latched<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(con
   // curr_qitr will never start at queue_.end() due to previous empty check
   auto curr_qitr = PolicyType::queue_.begin();
   auto prev_qitr = curr_qitr;
-  while (curr_qitr != PolicyType::queue_.end() and curr_qitr->stamp() <= boundary)
+  while (curr_qitr != PolicyType::queue_.end() and get_stamp(*curr_qitr) <= boundary)
   {
     prev_qitr = curr_qitr;
     ++curr_qitr;
@@ -107,7 +107,7 @@ State Latched<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(con
   latched_ = *prev_qitr;
 
   // Remove all elements before latched element
-  const auto prev_stamp = prev_qitr->stamp();
+  const auto prev_stamp = get_stamp(*prev_qitr);
   PolicyType::queue_.remove_before(prev_stamp);
   return State::PRIMED;
 }

--- a/flow/include/follower/impl/ranged.hpp
+++ b/flow/include/follower/impl/ranged.hpp
@@ -79,7 +79,7 @@ State Ranged<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
   std::copy(first_itr, last_itr, std::forward<OutputDispatchIteratorT>(output));
 
   // Remove data before first captured element
-  PolicyType::queue_.remove_before(first_itr->stamp());
+  PolicyType::queue_.remove_before(get_stamp(*first_itr));
 
   return State::PRIMED;
 }
@@ -110,7 +110,7 @@ State Ranged<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(cons
   else
   {
     // Remove data before first captured element
-    PolicyType::queue_.remove_before(std::prev(after_first_itr)->stamp());
+    PolicyType::queue_.remove_before(get_stamp(*std::prev(after_first_itr)));
     return State::PRIMED;
   }
 }
@@ -122,7 +122,7 @@ auto Ranged<DispatchT, LockPolicyT, AllocatorT>::find_after_first(const CaptureR
     PolicyType::queue_.begin(),
     PolicyType::queue_.end(),
     [offset_lower_stamp = (range.lower_stamp - delay_)](const DispatchT& dispatch) {
-      return dispatch.stamp() >= offset_lower_stamp;
+      return get_stamp(dispatch) >= offset_lower_stamp;
     });
 }
 
@@ -136,7 +136,7 @@ auto Ranged<DispatchT, LockPolicyT, AllocatorT>::find_before_last(
     after_first == PolicyType::queue_.end() ? PolicyType::queue_.begin() : after_first,
     PolicyType::queue_.end(),
     [offset_upper_stamp = (range.upper_stamp - delay_)](const DispatchT& dispatch) {
-      return dispatch.stamp() <= offset_upper_stamp;
+      return get_stamp(dispatch) <= offset_upper_stamp;
     });
 }
 

--- a/flow/include/impl/dispatch_queue.hpp
+++ b/flow/include/impl/dispatch_queue.hpp
@@ -52,7 +52,7 @@ void DispatchQueue<DispatchT, AllocatorT>::insert(DispatchConstructorArgTs&&... 
 
   // If data to add is ordered with respect to current queue,
   // add to back (as newest element)
-  if (queue_.empty() or (queue_.back().stamp() < dispatch.stamp()))
+  if (queue_.empty() or (get_stamp(queue_.back()) < get_stamp(dispatch)))
   {
     queue_.emplace_back(std::move(dispatch));
     return;
@@ -60,7 +60,7 @@ void DispatchQueue<DispatchT, AllocatorT>::insert(DispatchConstructorArgTs&&... 
 
   // Find next best placement
   auto qitr = queue_.end();
-  while ((--qitr)->stamp() > dispatch.stamp())
+  while (get_stamp(*(--qitr)) > get_stamp(dispatch))
   {
     if (qitr == queue_.begin())
     {
@@ -70,7 +70,7 @@ void DispatchQueue<DispatchT, AllocatorT>::insert(DispatchConstructorArgTs&&... 
   }
 
   // Insert only if this element does not duplicate an existing element
-  if (qitr->stamp() != dispatch.stamp())
+  if (get_stamp(*qitr) != get_stamp(dispatch))
   {
     queue_.emplace(std::next(qitr), std::move(dispatch));
   }
@@ -94,7 +94,7 @@ template <typename DispatchT, typename AllocatorT> void DispatchQueue<DispatchT,
 template <typename DispatchT, typename AllocatorT>
 void DispatchQueue<DispatchT, AllocatorT>::remove_before(const stamp_type& t)
 {
-  while (!queue_.empty() and queue_.front().stamp() < t)
+  while (!queue_.empty() and get_stamp(queue_.front()) < t)
   {
     queue_.pop_front();
   }
@@ -104,7 +104,7 @@ void DispatchQueue<DispatchT, AllocatorT>::remove_before(const stamp_type& t)
 template <typename DispatchT, typename AllocatorT>
 void DispatchQueue<DispatchT, AllocatorT>::remove_at_before(const stamp_type& t)
 {
-  while (!queue_.empty() and queue_.front().stamp() <= t)
+  while (!queue_.empty() and get_stamp(queue_.front()) <= t)
   {
     queue_.pop_front();
   }

--- a/flow/test/unit/captor.cpp
+++ b/flow/test/unit/captor.cpp
@@ -50,8 +50,8 @@ TEST(Captor, InspectCallback)
   std::size_t call_count = 0;
   captor.inspect([&call_count](const Dispatch<int, int>& dispatch) {
     ++call_count;
-    ASSERT_EQ(dispatch.stamp(), 0);
-    ASSERT_EQ(dispatch.data(), 1);
+    ASSERT_EQ(get_stamp(dispatch), 0);
+    ASSERT_EQ(get_value(dispatch), 1);
   });
 
   ASSERT_EQ(call_count, 1UL);

--- a/flow/test/unit/dispatch.cpp
+++ b/flow/test/unit/dispatch.cpp
@@ -33,7 +33,7 @@ TEST(Dispatch, GetData)
 {
   Dispatch<int, std::string> d{2, "test-value"};
 
-  EXPECT_EQ(d.data(), "test-value");
+  EXPECT_EQ(get_value(d), "test-value");
 }
 
 
@@ -41,7 +41,7 @@ TEST(Dispatch, GetStamp)
 {
   Dispatch<int, std::string> d{3, "test-value"};
 
-  EXPECT_EQ(d.stamp(), 3);
+  EXPECT_EQ(get_stamp(d), 3);
 }
 
 #endif  // DOXYGEN_SKIP

--- a/flow/test/unit/dispatch_queue.cpp
+++ b/flow/test/unit/dispatch_queue.cpp
@@ -207,8 +207,8 @@ TEST(DispatchQueue, InsertDuplicateTimeBehavior)
 
   const auto p0 = queue.pop();
 
-  EXPECT_EQ(p0.stamp(), t0);
-  EXPECT_EQ(p0.data(), 1);
+  EXPECT_EQ(get_stamp(p0), t0);
+  EXPECT_EQ(get_value(p0), 1);
 }
 
 
@@ -232,8 +232,8 @@ TEST(DispatchQueue, InsertOrdered)
   const auto p1 = queue.pop();
   const auto p2 = queue.pop();
 
-  EXPECT_LT(p0.stamp(), p1.stamp());
-  EXPECT_LT(p1.stamp(), p2.stamp());
+  EXPECT_LT(get_stamp(p0), get_stamp(p1));
+  EXPECT_LT(get_stamp(p1), get_stamp(p2));
 }
 
 
@@ -257,8 +257,8 @@ TEST(DispatchQueue, InsertUnordered)
   const auto p1 = queue.pop();
   const auto p2 = queue.pop();
 
-  EXPECT_LT(p0.stamp(), p1.stamp());
-  EXPECT_LT(p1.stamp(), p2.stamp());
+  EXPECT_LT(get_stamp(p0), get_stamp(p1));
+  EXPECT_LT(get_stamp(p1), get_stamp(p2));
 }
 
 

--- a/flow/test/unit/follower/closest_before.cpp
+++ b/flow/test/unit/follower/closest_before.cpp
@@ -90,7 +90,7 @@ TEST_F(FollowerClosestBefore, CapturePrimedAtDataBoundary)
   std::vector<Dispatch<int, int>> data;
   CaptureRange<int> t_range{t_target, t_target};
   ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
-  ASSERT_EQ(data.back().data(), t_target - DELAY - PERIOD);
+  ASSERT_EQ(get_value(data.back()), t_target - DELAY - PERIOD);
 
   ASSERT_EQ(this->size(), static_cast<std::size_t>(PERIOD + DELAY + 1));
 }
@@ -121,7 +121,7 @@ TEST_F(FollowerClosestBefore, CapturePrimedAtDataBoundaryFilledPast)
   std::vector<Dispatch<int, int>> data;
   CaptureRange<int> t_range{t_target, t_target};
   ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
-  ASSERT_EQ(data.back().data(), t_target - DELAY - PERIOD);
+  ASSERT_EQ(get_value(data.back()), t_target - DELAY - PERIOD);
 
   ASSERT_EQ(this->size(), static_cast<std::size_t>(3UL * (DELAY + PERIOD) - 2));
 }
@@ -144,7 +144,7 @@ TEST_F(FollowerClosestBefore, CapturePrimedClosestBeforeDataBeforePeriod)
   std::vector<Dispatch<int, int>> data;
   CaptureRange<int> t_range{t_target, t_target};
   ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
-  ASSERT_EQ(data.back().data(), t - DELAY - PERIOD);
+  ASSERT_EQ(get_value(data.back()), t - DELAY - PERIOD);
 
   ASSERT_EQ(this->size(), static_cast<std::size_t>(PERIOD + DELAY + 1));
 }

--- a/flow/test/unit/follower/count_before.cpp
+++ b/flow/test/unit/follower/count_before.cpp
@@ -192,7 +192,7 @@ TEST_F(FollowerCountBefore, PrimedWithExcessBefore)
 
   for (const auto& dispatch : data)
   {
-    const auto offset = dispatch.stamp() + DELAY;
+    const auto offset = get_stamp(dispatch) + DELAY;
     ASSERT_LT(offset, 0);
     ASSERT_GE(offset, -COUNT);
   }

--- a/flow/test/unit/follower/latched.cpp
+++ b/flow/test/unit/follower/latched.cpp
@@ -78,7 +78,7 @@ TEST_F(FollowerLatched, CapturePrimedOnMinPeriodStamp)
   ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
   ASSERT_EQ(this->size(), 1UL);
   ASSERT_EQ(data.size(), 1UL);
-  ASSERT_EQ(data.front().data(), 232);
+  ASSERT_EQ(get_value(data.front()), 232);
 }
 
 
@@ -93,7 +93,7 @@ TEST_F(FollowerLatched, CapturePrimedOnBeforeMinPeriodStamp)
   ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
   ASSERT_EQ(this->size(), 1UL);
   ASSERT_EQ(data.size(), 1UL);
-  ASSERT_EQ(data.front().data(), 232);
+  ASSERT_EQ(get_value(data.front()), 232);
 }
 
 
@@ -109,7 +109,7 @@ TEST_F(FollowerLatched, CapturePrimedOnBeforeMinPeriodStampTakeNewer)
   ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
   ASSERT_EQ(this->size(), 1UL);
   ASSERT_EQ(data.size(), 1UL);
-  ASSERT_EQ(data.front().data(), 233);
+  ASSERT_EQ(get_value(data.front()), 233);
 }
 
 
@@ -181,7 +181,7 @@ TEST_F(FollowerLatched, PrimedWithLatchedValue)
   ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range_successor));
   ASSERT_EQ(this->size(), 2UL);
   ASSERT_EQ(data.size(), 1UL);
-  ASSERT_EQ(data.front().data(), 232);
+  ASSERT_EQ(get_value(data.front()), 232);
 }
 
 


### PR DESCRIPTION
- Access specified through DispatchAccess, rather than through wrapper methods