### PR TITLE
(master) Containers not allocators

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ C++14, header-only library for multi-stream data synchronization.
 
 ## API Documentation
 
-Available [here](https://fetchrobotics.github.io/flow/doxygen-out/html/index.html).
+Documentation for latest version available [here](https://fetchrobotics.github.io/flow/doxygen-out/html/index.html).
 
 ## What is this used for?
 
@@ -43,7 +43,9 @@ Additionally, `flow::Captor` objects were designed to:
      + multi-threaded with blocking capture on asynchronous data injection
      + multi-threaded with polling for capture
      + single-threaded with polling for capture (no locking overhead)
-- be [allocator-aware](https://en.cppreference.com/w/cpp/named_req/AllocatorAwareContainer)
+- support customizable data storage
+     + users can supply custom underlying data containers (default is a [`std::deque`](https://en.cppreference.com/w/cpp/container/deque))
+     + in turn, this allows for easy specification of custom allocation methods
 - support input data generically through the use of a `Dispatch` concept and flexible data access (see below)
 - support generic data retrieval through use of [output iterators](https://en.cppreference.com/w/cpp/named_req/OutputIterator)
 
@@ -189,6 +191,30 @@ template <> struct DispatchTraits<::StampType>
 ```
 Partial specializations for [`std::chrono::time_point`](https://en.cppreference.com/w/cpp/chrono/time_point) templates are provided.
 
+
+### Data queue storage customization
+
+Captors utilize a `flow::DispatchQueue` for data ordering and retrieval. Users may supply a custom underlying container to manage this data. Refer to [`std::deque`](https://en.cppreference.com/w/cpp/container/deque) for more information on the listed requirements. The container type must supply the following:
+
+| Required member Type | Description |
+| -------------------- | ----------- |
+| `ContainerT::size_type`  | integer size type |
+| `ContainerT::const_iterator`  | immutable element iterator type |
+| `ContainerT::const_reverse_iterator`  | reverse-sequence immutable element iterator type |
+
+| Required method | Description |
+| --------------- | ----------- |
+| `ContainerT::cbegin`  | returns iterator to first immutable element |
+| `ContainerT::cend`  | returns iterator to one past last immutable element |
+| `ContainerT::crbegin`  | returns reverse iterator to last immutable element |
+| `ContainerT::crend` | returns reverse iterator to one past first immutable element
+| `ContainerT::emplace_back`  | constructs an element, in place, at last position in the container |
+| `ContainerT::emplace`  | constructs an element, in place, after a specified iterator position |
+| `ContainerT::size`  | returns the number of elements in the container |
+| `ContainerT::pop_front`  | removes first element in the container |
+| `ContainerT::front`  | returns immutable reference to first element in the container |
+| `ContainerT::back`  | returns immutable reference to last element in the container |
+| `ContainerT::clear`  | clears available container contents |
 
 ## Captor Synchronization Policies
 

--- a/flow/include/captor.h
+++ b/flow/include/captor.h
@@ -11,7 +11,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
-#include <memory>
+#include <deque>
 #include <mutex>
 #include <thread>
 #include <type_traits>
@@ -26,6 +26,12 @@
 
 namespace flow
 {
+
+/**
+ * @brief Default dispatch container template
+ */
+template <typename DispatchT> using DefaultContainer = std::deque<DispatchT>;
+
 
 /**
  * @brief Stand-in type used to signify that captors will be used in a single-threaded context
@@ -82,7 +88,7 @@ template <typename DispatchT> struct CaptorTraitsFromDispatch
  *
  *        Requires:
  *        - <code>DispatchType</code> : data dispatch object type
- *        - <code>DispatchAllocatorType</code> : allocator for <code>DispatchType</code>
+ *        - <code>DispatchContainerType</code> : container for <code>DispatchType</code>
  *        - <code>value_type</code> : data value type
  *        - <code>stamp_type</code> : sequence stamp type
  *        - <code>size_type</code> : integer sizing type
@@ -101,8 +107,8 @@ public:
   /// Data dispatch type
   using DispatchType = typename CaptorTraits<CaptorT>::DispatchType;
 
-  /// Data dispatch allocator type
-  using DispatchAllocatorType = typename CaptorTraits<CaptorT>::DispatchAllocatorType;
+  /// Data dispatch container type
+  using DispatchContainerType = typename CaptorTraits<CaptorT>::DispatchContainerType;
 
   /// Data stamp type
   using stamp_type = typename CaptorTraits<CaptorT>::stamp_type;
@@ -121,9 +127,9 @@ public:
    * @brief Full setup constructor
    *
    * @param capacity  maximum buffer capacity
-   * @param alloc  dispatch allocator type for underlying queue
+   * @param container  dispatch container type for underlying queue
    */
-  explicit CaptorInterface(const size_type capacity, const DispatchAllocatorType& alloc);
+  explicit CaptorInterface(const size_type capacity, const DispatchContainerType& container);
 
   /**
    * @brief Clears all captor data and resets all states
@@ -289,9 +295,9 @@ public:
   }
 
   /**
-   * @brief Returns the allocator associated with the underlying dispatch queue
+   * @brief Returns the container associated with the underlying dispatch queue
    */
-  inline DispatchAllocatorType get_allocator() const noexcept { return queue_.get_allocator(); }
+  inline const DispatchContainerType& get_container() const noexcept { return queue_.get_container(); }
 
   // Sanity check to ensure that DispatchType is copyable
   FLOW_STATIC_ASSERT(std::is_copy_constructible<DispatchType>(), "'DispatchType' must be a copyable type");
@@ -307,7 +313,7 @@ protected:
   template <typename... InsertArgTs> inline void insert_and_limit(InsertArgTs&&... args);
 
   /// Data dispatch queue
-  DispatchQueue<DispatchType, DispatchAllocatorType> queue_;
+  DispatchQueue<DispatchType, DispatchContainerType> queue_;
 
   /// Buffered data capacity
   size_type capacity_;
@@ -330,8 +336,8 @@ public:
   /// Data dispatch type
   using DispatchType = typename CaptorTraits<CaptorT>::DispatchType;
 
-  /// Data dispatch allocator type
-  using DispatchAllocatorType = typename CaptorTraits<CaptorT>::DispatchAllocatorType;
+  /// Data dispatch container type
+  using DispatchContainerType = typename CaptorTraits<CaptorT>::DispatchContainerType;
 
   /// Data stamp type
   using stamp_type = typename CaptorTraits<CaptorT>::stamp_type;
@@ -345,11 +351,11 @@ public:
   Captor();
 
   /**
-   * @brief Dispatch allocator constructor
+   * @brief Dispatch container constructor
    *
-   * @param alloc  allocator object with some initial state
+   * @param container  container object with some initial state
    */
-  explicit Captor(const DispatchAllocatorType& alloc);
+  explicit Captor(const DispatchContainerType& container);
 
   /**
    * @brief Destructor

--- a/flow/include/dispatch_ostream.h
+++ b/flow/include/dispatch_ostream.h
@@ -17,7 +17,7 @@ namespace flow
 {
 
 /**
- * @brief Output stream overload for <code>Dispatch</code> codes
+ * @brief Output stream overload for <code>Dispatch</code>
  * @param[in,out] os  output stream
  * @param dispatch  dispatch object
  * @return os
@@ -30,7 +30,7 @@ inline std::ostream& operator<<(std::ostream& os, const Dispatch<StampT, ValueT>
 
 
 /**
- * @brief Output stream overload for <code>CaptureRange</code> codes
+ * @brief Output stream overload for <code>CaptureRange</code>
  *
  * @param[in,out] os  output stream
  * @param range  capture stamp range

--- a/flow/include/dispatch_queue.h
+++ b/flow/include/dispatch_queue.h
@@ -22,13 +22,13 @@ namespace flow
  *
  *        FILO-type queue which orders data by sequence stamp, from oldest to newest. Provides
  *        useful methods for extracting data within stamped/counted ranges
- *
- *        This container is based on an <code>std::deque</code> and is allocator-aware
+ * \n
+ *        This template provides an interface wrapper around a specifiable container implementation.
  *
  * @tparam DispatchT  data dipatch type
- * @tparam AllocatorT <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container timplementation
  */
-template <typename DispatchT, typename AllocatorT = std::allocator<DispatchT>> class DispatchQueue
+template <typename DispatchT, typename ContainerT = std::deque<DispatchT>> class DispatchQueue
 {
 public:
   /// Dispatch stamp type
@@ -37,17 +37,14 @@ public:
   /// Dispatch data value type
   using value_type = typename DispatchTraits<DispatchT>::value_type;
 
-  /// Underlying container alias
-  using BaseContainerType = std::deque<DispatchT>;
-
   /// Sizing type alias
-  using size_type = typename BaseContainerType::size_type;
+  using size_type = typename ContainerT::size_type;
 
   /// Iterator type for container Dispatch elements
-  using const_iterator = typename BaseContainerType::const_iterator;
+  using const_iterator = typename ContainerT::const_iterator;
 
   /// Iterator type for container Dispatch elements
-  using const_reverse_iterator = typename BaseContainerType::const_reverse_iterator;
+  using const_reverse_iterator = typename ContainerT::const_reverse_iterator;
 
   /**
    * @brief Default construtor
@@ -57,7 +54,7 @@ public:
   /**
    * @brief Allocator construtor
    */
-  explicit DispatchQueue(const AllocatorT& alloc);
+  explicit DispatchQueue(const ContainerT& container);
 
   /**
    * @brief Returns the number queued elements
@@ -65,7 +62,10 @@ public:
   inline size_type size() const;
 
   /**
-   * @brief Returns the number queued elements
+   * @brief Checks if queue is empty
+   *
+   * @retval true  if not elements remain in queue
+   * @retval false  otherwise
    */
   inline bool empty() const;
 
@@ -73,25 +73,25 @@ public:
    * @brief Returns first iterator to underlying ordered data structure
    * @return <code>const_iterator</code> to first Dispatch resource
    */
-  inline const_iterator begin() const { return queue_.cbegin(); }
+  inline const_iterator begin() const { return container_.cbegin(); }
 
   /**
    * @brief Returns last iterator to underlying ordered data structure
    * @return <code>const_iterator</code> to one element past Dispatch resource
    */
-  inline const_iterator end() const { return queue_.cend(); }
+  inline const_iterator end() const { return container_.cend(); }
 
   /**
    * @brief Returns first iterator to reversed underlying ordered data structure
    * @return <code>const_reverse_iterator</code> to first Dispatch resource
    */
-  inline const_reverse_iterator rbegin() const { return queue_.crbegin(); }
+  inline const_reverse_iterator rbegin() const { return container_.crbegin(); }
 
   /**
    * @brief Returns last iterator to reversed underlying ordered data structure
    * @return <code>const_reverse_iterator</code> to one element past Dispatch resource
    */
-  inline const_reverse_iterator rend() const { return queue_.crend(); }
+  inline const_reverse_iterator rend() const { return container_.crend(); }
 
   /**
    * @brief Sequencing stamp associated with the oldest data
@@ -99,7 +99,7 @@ public:
    *
    * @warning Undefined behavior when <code>empty() == true</code>
    */
-  inline stamp_type oldest_stamp() const { return get_stamp(queue_.front()); }
+  inline stamp_type oldest_stamp() const { return get_stamp(container_.front()); }
 
   /**
    * @brief Sequencing stamp associated with the newest data
@@ -107,7 +107,7 @@ public:
    *
    * @warning Undefined behavior when <code>empty() == true</code>
    */
-  inline stamp_type newest_stamp() const { return get_stamp(queue_.back()); }
+  inline stamp_type newest_stamp() const { return get_stamp(container_.back()); }
 
   /**
    * @brief Removes the oldest element and returns associated Dispatch
@@ -139,7 +139,7 @@ public:
    *
    * @param n  lower bound on total container size
    */
-  inline void shrink_to_fit(size_type n);
+  inline void shrink_to_fit(const size_type n);
 
   /**
    * @brief Inserts data in sequence stamp order as Dispatch
@@ -151,13 +151,13 @@ public:
   template <typename... DispatchConstructorArgTs> inline void insert(DispatchConstructorArgTs&&... dispatch_args);
 
   /**
-   * @brief Returns the allocator associated with the container
+   * @brief Returns the underlying storage container
    */
-  inline AllocatorT get_allocator() const noexcept;
+  inline const ContainerT& get_container() const noexcept;
 
 private:
   /// Queued data dispatches
-  BaseContainerType queue_;
+  ContainerT container_;
 };
 
 }  // namespace flow

--- a/flow/include/driver/batch.h
+++ b/flow/include/driver/batch.h
@@ -7,10 +7,6 @@
 #ifndef FLOW_DRIVER_BATCH_H
 #define FLOW_DRIVER_BATCH_H
 
-// C++ Standard Library
-#include <memory>
-#include <vector>
-
 // Flow
 #include <flow/captor.h>
 #include <flow/dispatch.h>
@@ -31,10 +27,10 @@ namespace driver
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class Batch : public Driver<Batch<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class Batch : public Driver<Batch<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Integer size type
@@ -51,21 +47,21 @@ public:
    * @throws <code>std::invalid_argument</code> if <code>size == 0</code>
    * @throws <code>std::invalid_argument</code> if <code>CaptureOutputT</code> cannot hold \p size
    */
-  explicit Batch(size_type size) noexcept(false);
+  explicit Batch(const size_type size) noexcept(false);
 
   /**
    * @brief Configuration constructor
    *
    * @param size  number of elements to batch before becoming ready
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    *
    * @throws <code>std::invalid_argument</code> if <code>size == 0</code>
    * @throws <code>std::invalid_argument</code> if <code>CaptureOutputT</code> cannot hold \p size
    */
-  explicit Batch(size_type size, const AllocatorT& alloc) noexcept(false);
+  explicit Batch(const size_type size, const ContainerT& container) noexcept(false);
 
 private:
-  using PolicyType = Driver<Batch<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Driver<Batch<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -113,14 +109,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<driver::Batch<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<driver::Batch<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/driver/chunk.h
+++ b/flow/include/driver/chunk.h
@@ -7,10 +7,6 @@
 #ifndef FLOW_DRIVER_CHUNK_H
 #define FLOW_DRIVER_CHUNK_H
 
-// C++ Standard Library
-#include <memory>
-#include <vector>
-
 // Flow
 #include <flow/captor.h>
 #include <flow/dispatch.h>
@@ -31,11 +27,11 @@ namespace driver
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  captured output container type
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class Chunk : public Driver<Chunk<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class Chunk : public Driver<Chunk<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Integer size type
@@ -52,21 +48,21 @@ public:
    * @throws <code>std::invalid_argument</code> if <code>size == 0</code>
    * @throws <code>std::invalid_argument</code> if <code>CaptureOutputT</code> cannot hold \p size
    */
-  explicit Chunk(size_type size) noexcept(false);
+  explicit Chunk(const size_type size) noexcept(false);
 
   /**
    * @brief Configuration constructor
    *
    * @param size  number of elements to batch before becoming ready
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    *
    * @throws <code>std::invalid_argument</code> if <code>size == 0</code>
    * @throws <code>std::invalid_argument</code> if <code>CaptureOutputT</code> cannot hold \p size
    */
-  explicit Chunk(size_type size, const AllocatorT& alloc) noexcept(false);
+  explicit Chunk(const size_type size, const ContainerT& container) noexcept(false);
 
 private:
-  using PolicyType = Driver<Chunk<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Driver<Chunk<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -114,14 +110,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<driver::Chunk<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<driver::Chunk<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/driver/driver.h
+++ b/flow/include/driver/driver.h
@@ -41,8 +41,8 @@ template <typename PolicyT>
 class Driver : public Captor<Driver<PolicyT>, typename CaptorTraits<PolicyT>::LockPolicyType>
 {
 public:
-  /// Data dispatch allocator type
-  using DispatchAllocatorType = typename CaptorTraits<PolicyT>::DispatchAllocatorType;
+  /// Underlying dispatch container type
+  using DispatchContainerType = typename CaptorTraits<PolicyT>::DispatchContainerType;
 
   /// Data stamp type
   using stamp_type = typename CaptorTraits<PolicyT>::stamp_type;
@@ -53,10 +53,10 @@ public:
   Driver();
 
   /**
-   * @brief Dispatch allocator constructor
-   * @param alloc  dispatch object allocator with some initial state
+   * @brief Dispatch container constructor
+   * @param container  dispatch object container (non-default initialization)
    */
-  explicit Driver(const DispatchAllocatorType& alloc);
+  explicit Driver(const DispatchContainerType& container);
 
 private:
   /**

--- a/flow/include/driver/impl/batch.hpp
+++ b/flow/include/driver/impl/batch.hpp
@@ -16,25 +16,25 @@ namespace flow
 namespace driver
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Batch<DispatchT, LockPolicyT, AllocatorT>::Batch(size_type size) noexcept(false) : batch_size_{size}
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Batch<DispatchT, LockPolicyT, ContainerT>::Batch(const size_type size) noexcept(false) : batch_size_{size}
 {
   validate();
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Batch<DispatchT, LockPolicyT, AllocatorT>::Batch(size_type size, const AllocatorT& alloc) noexcept(false) :
-    PolicyType{alloc},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Batch<DispatchT, LockPolicyT, ContainerT>::Batch(const size_type size, const ContainerT& container) noexcept(false) :
+    PolicyType{container},
     batch_size_{size}
 {
   validate();
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State Batch<DispatchT, LockPolicyT, AllocatorT>::capture_driver_impl(
+State Batch<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
   OutputDispatchIteratorT output,
   CaptureRange<stamp_type>& range)
 {
@@ -53,8 +53,8 @@ State Batch<DispatchT, LockPolicyT, AllocatorT>::capture_driver_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State Batch<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State Batch<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
 {
   if (PolicyType::queue_.size() >= batch_size_)
   {
@@ -72,15 +72,15 @@ State Batch<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(Capture
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Batch<DispatchT, LockPolicyT, AllocatorT>::abort_driver_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Batch<DispatchT, LockPolicyT, ContainerT>::abort_driver_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort);
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Batch<DispatchT, LockPolicyT, AllocatorT>::validate() const noexcept(false)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Batch<DispatchT, LockPolicyT, ContainerT>::validate() const noexcept(false)
 {
   if (batch_size_ == 0)
   {

--- a/flow/include/driver/impl/chunk.hpp
+++ b/flow/include/driver/impl/chunk.hpp
@@ -17,25 +17,25 @@ namespace flow
 namespace driver
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Chunk<DispatchT, LockPolicyT, AllocatorT>::Chunk(size_type size) noexcept(false) : PolicyType{}, chunk_size_{size}
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Chunk<DispatchT, LockPolicyT, ContainerT>::Chunk(const size_type size) noexcept(false) : PolicyType{}, chunk_size_{size}
 {
   validate();
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Chunk<DispatchT, LockPolicyT, AllocatorT>::Chunk(size_type size, const AllocatorT& alloc) noexcept(false) :
-    PolicyType{alloc},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Chunk<DispatchT, LockPolicyT, ContainerT>::Chunk(const size_type size, const ContainerT& container) noexcept(false) :
+    PolicyType{container},
     chunk_size_{size}
 {
   validate();
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State Chunk<DispatchT, LockPolicyT, AllocatorT>::capture_driver_impl(
+State Chunk<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
   OutputDispatchIteratorT output,
   CaptureRange<stamp_type>& range)
 {
@@ -56,8 +56,8 @@ State Chunk<DispatchT, LockPolicyT, AllocatorT>::capture_driver_impl(
   return state;
 }
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State Chunk<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State Chunk<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
 {
   if (PolicyType::queue_.size() >= chunk_size_)
   {
@@ -74,15 +74,15 @@ State Chunk<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(Capture
   }
 }
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Chunk<DispatchT, LockPolicyT, AllocatorT>::abort_driver_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Chunk<DispatchT, LockPolicyT, ContainerT>::abort_driver_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort);
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Chunk<DispatchT, LockPolicyT, AllocatorT>::validate() const noexcept(false)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Chunk<DispatchT, LockPolicyT, ContainerT>::validate() const noexcept(false)
 {
   if (chunk_size_ == 0)
   {

--- a/flow/include/driver/impl/driver.hpp
+++ b/flow/include/driver/impl/driver.hpp
@@ -19,7 +19,7 @@ namespace flow
 template <typename PolicyT> Driver<PolicyT>::Driver() : CaptorType{} {}
 
 
-template <typename PolicyT> Driver<PolicyT>::Driver(const DispatchAllocatorType& alloc) : CaptorType{alloc} {}
+template <typename PolicyT> Driver<PolicyT>::Driver(const DispatchContainerType& container) : CaptorType{container} {}
 
 
 template <typename PolicyT>

--- a/flow/include/driver/impl/next.hpp
+++ b/flow/include/driver/impl/next.hpp
@@ -12,14 +12,14 @@ namespace flow
 namespace driver
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Next<DispatchT, LockPolicyT, AllocatorT>::Next(const AllocatorT& alloc) noexcept(false) : PolicyType{alloc}
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Next<DispatchT, LockPolicyT, ContainerT>::Next(const ContainerT& container) noexcept(false) : PolicyType{container}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State Next<DispatchT, LockPolicyT, AllocatorT>::capture_driver_impl(
+State Next<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
   OutputDispatchIteratorT output,
   CaptureRange<stamp_type>& range)
 {
@@ -35,8 +35,8 @@ State Next<DispatchT, LockPolicyT, AllocatorT>::capture_driver_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State Next<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State Next<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
 {
   if (PolicyType::queue_.empty())
   {
@@ -52,8 +52,8 @@ State Next<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(CaptureR
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Next<DispatchT, LockPolicyT, AllocatorT>::abort_driver_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Next<DispatchT, LockPolicyT, ContainerT>::abort_driver_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort);
 }

--- a/flow/include/driver/impl/throttled.hpp
+++ b/flow/include/driver/impl/throttled.hpp
@@ -15,27 +15,27 @@ namespace flow
 namespace driver
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Throttled<DispatchT, LockPolicyT, AllocatorT>::Throttled(const offset_type throttle_period) noexcept(false) :
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Throttled<DispatchT, LockPolicyT, ContainerT>::Throttled(const offset_type throttle_period) noexcept(false) :
     PolicyType{},
     throttle_period_{throttle_period},
     previous_stamp_{StampTraits<stamp_type>::min()}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Throttled<DispatchT, LockPolicyT, AllocatorT>::Throttled(
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Throttled<DispatchT, LockPolicyT, ContainerT>::Throttled(
   const offset_type throttle_period,
-  const AllocatorT& alloc) noexcept(false) :
-    PolicyType{alloc},
+  const ContainerT& container) noexcept(false) :
+    PolicyType{container},
     throttle_period_{throttle_period},
     previous_stamp_{StampTraits<stamp_type>::min()}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State Throttled<DispatchT, LockPolicyT, AllocatorT>::capture_driver_impl(
+State Throttled<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
   OutputDispatchIteratorT output,
   CaptureRange<stamp_type>& range)
 {
@@ -57,8 +57,8 @@ State Throttled<DispatchT, LockPolicyT, AllocatorT>::capture_driver_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State Throttled<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State Throttled<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
 {
   for (const auto& dispatch : PolicyType::queue_)
   {
@@ -75,15 +75,15 @@ State Throttled<DispatchT, LockPolicyT, AllocatorT>::dry_capture_driver_impl(Cap
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Throttled<DispatchT, LockPolicyT, AllocatorT>::abort_driver_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Throttled<DispatchT, LockPolicyT, ContainerT>::abort_driver_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort);
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Throttled<DispatchT, LockPolicyT, AllocatorT>::reset_driver_impl()
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Throttled<DispatchT, LockPolicyT, ContainerT>::reset_driver_impl()
 {
   previous_stamp_ = StampTraits<stamp_type>::min();
 }

--- a/flow/include/driver/next.h
+++ b/flow/include/driver/next.h
@@ -7,10 +7,6 @@
 #ifndef FLOW_DRIVER_NEXT_H
 #define FLOW_DRIVER_NEXT_H
 
-// C++ Standard Library
-#include <memory>
-#include <vector>
-
 // Flow
 #include <flow/captor.h>
 #include <flow/dispatch.h>
@@ -30,11 +26,11 @@ namespace driver
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  captured output container type
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class Next : public Driver<Next<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class Next : public Driver<Next<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Integer size type
@@ -50,12 +46,12 @@ public:
 
   /**
    * @brief Configuration constructor
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    */
-  explicit Next(const AllocatorT& alloc);
+  explicit Next(const ContainerT& container);
 
 private:
-  using PolicyType = Driver<Next<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Driver<Next<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -95,14 +91,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<driver::Next<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<driver::Next<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/driver/throttled.h
+++ b/flow/include/driver/throttled.h
@@ -7,10 +7,6 @@
 #ifndef FLOW_DRIVER_THROTTLED_H
 #define FLOW_DRIVER_THROTTLED_H
 
-// C++ Standard Library
-#include <memory>
-#include <vector>
-
 // Flow
 #include <flow/captor.h>
 #include <flow/dispatch.h>
@@ -33,11 +29,11 @@ namespace driver
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  captured output container type
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class Throttled : public Driver<Throttled<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class Throttled : public Driver<Throttled<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Data stamp type
@@ -57,12 +53,12 @@ public:
    * @brief Configuration constructor
    *
    * @param throttle_period  capture throttling period
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    */
-  explicit Throttled(const offset_type throttle_period, const AllocatorT& alloc);
+  explicit Throttled(const offset_type throttle_period, const ContainerT& container);
 
 private:
-  using PolicyType = Driver<Throttled<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Driver<Throttled<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -108,14 +104,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<driver::Throttled<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<driver::Throttled<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/follower/any_before.h
+++ b/flow/include/follower/any_before.h
@@ -32,14 +32,14 @@ namespace follower
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  *
  * @warn This captor WILL NOT behave deterministically if all data is not available before capture time minus
  *       the specified delay. As such, setting the delay properly will alleviate non-deterministic behavior.
  *       This is the only <i>optional</i> captor, and should be used with great caution.
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class AnyBefore : public Follower<AnyBefore<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class AnyBefore : public Follower<AnyBefore<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Data stamp type
@@ -57,12 +57,12 @@ public:
   /**
    * @brief Setup constructor
    * @param delay  the delay with which to capture
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    */
-  AnyBefore(const offset_type& delay, const AllocatorT& alloc);
+  AnyBefore(const offset_type& delay, const ContainerT& container);
 
 private:
-  using PolicyType = Follower<AnyBefore<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Follower<AnyBefore<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -104,14 +104,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<follower::AnyBefore<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<follower::AnyBefore<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/follower/before.h
+++ b/flow/include/follower/before.h
@@ -24,10 +24,10 @@ namespace follower
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class Before : public Follower<Before<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class Before : public Follower<Before<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Data stamp type
@@ -45,12 +45,12 @@ public:
   /**
    * @brief Setup constructor
    * @param delay  the delay with which to capture
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    */
-  Before(const offset_type& delay, const AllocatorT& alloc);
+  Before(const offset_type& delay, const ContainerT& container);
 
 private:
-  using PolicyType = Follower<Before<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Follower<Before<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -94,14 +94,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<follower::Before<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<follower::Before<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/follower/closest_before.h
+++ b/flow/include/follower/closest_before.h
@@ -23,15 +23,15 @@ namespace follower
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  *
  * @warn ClosestBefore will behave non-deterministically if actual input period (difference between successive
  *       dispatch stamps) does not match the <code>period</code> argument specified on construction. For example,
  *       if <code>period</code> is too large, than multiple inputs could appear before the driving range, causing
  *       for different data on two or more iterations where the "latest" data was assumed to have been the same
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class ClosestBefore : public Follower<ClosestBefore<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class ClosestBefore : public Follower<ClosestBefore<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Data stamp type
@@ -53,12 +53,12 @@ public:
    *
    * @param period  expected half-period between successive data elements
    * @param delay  the delay with which to capture
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    */
-  ClosestBefore(const offset_type& period, const offset_type& delay, const AllocatorT& alloc);
+  ClosestBefore(const offset_type& period, const offset_type& delay, const ContainerT& container);
 
 private:
-  using PolicyType = Follower<ClosestBefore<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Follower<ClosestBefore<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -107,14 +107,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<follower::ClosestBefore<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<follower::ClosestBefore<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/follower/count_before.h
+++ b/flow/include/follower/count_before.h
@@ -23,10 +23,10 @@ namespace follower
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class CountBefore : public Follower<CountBefore<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class CountBefore : public Follower<CountBefore<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Integer size type
@@ -53,14 +53,14 @@ public:
    *
    * @param count  number of elements before to capture
    * @param delay  the delay with which to capture
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    *
    * @throws <code>std::invalid_argument</code> if <code>count == 0</code>
    */
-  CountBefore(const size_type count, const offset_type& delay, const AllocatorT& alloc);
+  CountBefore(const size_type count, const offset_type& delay, const ContainerT& container);
 
 private:
-  using PolicyType = Follower<CountBefore<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Follower<CountBefore<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -108,14 +108,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<follower::CountBefore<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<follower::CountBefore<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/follower/follower.h
+++ b/flow/include/follower/follower.h
@@ -41,8 +41,8 @@ template <typename PolicyT>
 class Follower : public Captor<Follower<PolicyT>, typename CaptorTraits<PolicyT>::LockPolicyType>
 {
 public:
-  /// Data dispatch allocator type
-  using DispatchAllocatorType = typename CaptorTraits<PolicyT>::DispatchAllocatorType;
+  /// Underlying dispatch container type
+  using DispatchContainerType = typename CaptorTraits<PolicyT>::DispatchContainerType;
 
   /// Data stamp type
   using stamp_type = typename CaptorTraits<PolicyT>::stamp_type;
@@ -54,9 +54,9 @@ public:
 
   /**
    * @brief Timeout specification constructor
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    */
-  explicit Follower(const DispatchAllocatorType& alloc);
+  explicit Follower(const DispatchContainerType& container);
 
 private:
   /**

--- a/flow/include/follower/impl/any_before.hpp
+++ b/flow/include/follower/impl/any_before.hpp
@@ -18,21 +18,21 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-AnyBefore<DispatchT, LockPolicyT, AllocatorT>::AnyBefore(const offset_type& delay) : delay_{delay}
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+AnyBefore<DispatchT, LockPolicyT, ContainerT>::AnyBefore(const offset_type& delay) : delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-AnyBefore<DispatchT, LockPolicyT, AllocatorT>::AnyBefore(const offset_type& delay, const AllocatorT& alloc) :
-    PolicyType{alloc},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+AnyBefore<DispatchT, LockPolicyT, ContainerT>::AnyBefore(const offset_type& delay, const ContainerT& container) :
+    PolicyType{container},
     delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State AnyBefore<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
+State AnyBefore<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -52,16 +52,16 @@ State AnyBefore<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State AnyBefore<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State AnyBefore<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(
   const CaptureRange<stamp_type>& range) const
 {
   return State::PRIMED;
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void AnyBefore<DispatchT, LockPolicyT, AllocatorT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void AnyBefore<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort - delay_);
 }

--- a/flow/include/follower/impl/before.hpp
+++ b/flow/include/follower/impl/before.hpp
@@ -18,21 +18,21 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Before<DispatchT, LockPolicyT, AllocatorT>::Before(const offset_type& delay) : delay_{delay}
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Before<DispatchT, LockPolicyT, ContainerT>::Before(const offset_type& delay) : delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Before<DispatchT, LockPolicyT, AllocatorT>::Before(const offset_type& delay, const AllocatorT& alloc) :
-    PolicyType{alloc},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Before<DispatchT, LockPolicyT, ContainerT>::Before(const offset_type& delay, const ContainerT& container) :
+    PolicyType{container},
     delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State Before<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
+State Before<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -64,16 +64,16 @@ State Before<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State Before<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State Before<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range) const
 {
   const stamp_type boundary = range.upper_stamp - delay_;
   return (PolicyType::queue_.empty() or PolicyType::queue_.newest_stamp() < boundary) ? State::RETRY : State::PRIMED;
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Before<DispatchT, LockPolicyT, AllocatorT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Before<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort - delay_);
 }

--- a/flow/include/follower/impl/closest_before.hpp
+++ b/flow/include/follower/impl/closest_before.hpp
@@ -12,28 +12,28 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-ClosestBefore<DispatchT, LockPolicyT, AllocatorT>::ClosestBefore(const offset_type& period, const offset_type& delay) :
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+ClosestBefore<DispatchT, LockPolicyT, ContainerT>::ClosestBefore(const offset_type& period, const offset_type& delay) :
     PolicyType{},
     period_{period},
     delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-ClosestBefore<DispatchT, LockPolicyT, AllocatorT>::ClosestBefore(
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+ClosestBefore<DispatchT, LockPolicyT, ContainerT>::ClosestBefore(
   const offset_type& period,
   const offset_type& delay,
-  const AllocatorT& alloc) :
-    PolicyType{alloc},
+  const ContainerT& container) :
+    PolicyType{container},
     period_{period},
     delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State ClosestBefore<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
+State ClosestBefore<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -49,8 +49,8 @@ State ClosestBefore<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State ClosestBefore<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State ClosestBefore<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(
   const CaptureRange<stamp_type>& range)
 {
   // The boundary before which messages are valid and after which they are not. Non-inclusive.
@@ -87,8 +87,8 @@ State ClosestBefore<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_im
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void ClosestBefore<DispatchT, LockPolicyT, AllocatorT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void ClosestBefore<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort - delay_ - period_);
 }

--- a/flow/include/follower/impl/count_before.hpp
+++ b/flow/include/follower/impl/count_before.hpp
@@ -17,8 +17,8 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-CountBefore<DispatchT, LockPolicyT, AllocatorT>::CountBefore(const size_type count, const offset_type& delay) :
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+CountBefore<DispatchT, LockPolicyT, ContainerT>::CountBefore(const size_type count, const offset_type& delay) :
     count_{count},
     delay_{delay}
 {
@@ -29,12 +29,12 @@ CountBefore<DispatchT, LockPolicyT, AllocatorT>::CountBefore(const size_type cou
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-CountBefore<DispatchT, LockPolicyT, AllocatorT>::CountBefore(
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+CountBefore<DispatchT, LockPolicyT, ContainerT>::CountBefore(
   const size_type count,
   const offset_type& delay,
-  const AllocatorT& alloc) :
-    PolicyType{alloc},
+  const ContainerT& container) :
+    PolicyType{container},
     count_{count},
     delay_{delay}
 {
@@ -45,9 +45,9 @@ CountBefore<DispatchT, LockPolicyT, AllocatorT>::CountBefore(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State CountBefore<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
+State CountBefore<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -63,8 +63,8 @@ State CountBefore<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State CountBefore<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State CountBefore<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
 {
   // Retry if queue has no data
   if (PolicyType::queue_.empty())

--- a/flow/include/follower/impl/follower.hpp
+++ b/flow/include/follower/impl/follower.hpp
@@ -19,7 +19,8 @@ namespace flow
 template <typename PolicyT> Follower<PolicyT>::Follower() : CaptorType{} {}
 
 
-template <typename PolicyT> Follower<PolicyT>::Follower(const DispatchAllocatorType& alloc) : CaptorType{alloc} {}
+template <typename PolicyT> Follower<PolicyT>::Follower(const DispatchContainerType& container) : CaptorType{container}
+{}
 
 
 template <typename PolicyT>

--- a/flow/include/follower/impl/latched.hpp
+++ b/flow/include/follower/impl/latched.hpp
@@ -15,23 +15,23 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Latched<DispatchT, LockPolicyT, AllocatorT>::Latched(const offset_type min_period) :
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Latched<DispatchT, LockPolicyT, ContainerT>::Latched(const offset_type min_period) :
     PolicyType{},
     min_period_{min_period}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Latched<DispatchT, LockPolicyT, AllocatorT>::Latched(const offset_type min_period, const AllocatorT& alloc) :
-    PolicyType{alloc},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Latched<DispatchT, LockPolicyT, ContainerT>::Latched(const offset_type min_period, const ContainerT& container) :
+    PolicyType{container},
     min_period_{min_period}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State Latched<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
+State Latched<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -47,8 +47,8 @@ State Latched<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State Latched<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State Latched<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
 {
   if (PolicyType::queue_.empty())
   {
@@ -101,15 +101,15 @@ State Latched<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(con
   return State::PRIMED;
 }
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Latched<DispatchT, LockPolicyT, AllocatorT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Latched<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
 {
   // don't remove anything abort
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Latched<DispatchT, LockPolicyT, AllocatorT>::reset_follower_impl() noexcept(true)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Latched<DispatchT, LockPolicyT, ContainerT>::reset_follower_impl() noexcept(true)
 {
   latched_.reset();
 }

--- a/flow/include/follower/impl/matched_stamp.hpp
+++ b/flow/include/follower/impl/matched_stamp.hpp
@@ -15,14 +15,14 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-MatchedStamp<DispatchT, LockPolicyT, AllocatorT>::MatchedStamp(const AllocatorT& alloc) : PolicyType{alloc}
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+MatchedStamp<DispatchT, LockPolicyT, ContainerT>::MatchedStamp(const ContainerT& container) : PolicyType{container}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State MatchedStamp<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
+State MatchedStamp<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -38,8 +38,8 @@ State MatchedStamp<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State MatchedStamp<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State MatchedStamp<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
 {
   // Remove all elements before leading time
   PolicyType::queue_.remove_before(range.lower_stamp);
@@ -58,8 +58,8 @@ State MatchedStamp<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_imp
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void MatchedStamp<DispatchT, LockPolicyT, AllocatorT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void MatchedStamp<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort);
 }

--- a/flow/include/follower/impl/ranged.hpp
+++ b/flow/include/follower/impl/ranged.hpp
@@ -18,21 +18,21 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Ranged<DispatchT, LockPolicyT, AllocatorT>::Ranged(const offset_type& delay) : PolicyType{}, delay_{delay}
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Ranged<DispatchT, LockPolicyT, ContainerT>::Ranged(const offset_type& delay) : PolicyType{}, delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-Ranged<DispatchT, LockPolicyT, AllocatorT>::Ranged(const offset_type& delay, const AllocatorT& alloc) :
-    PolicyType{alloc},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+Ranged<DispatchT, LockPolicyT, ContainerT>::Ranged(const offset_type& delay, const ContainerT& container) :
+    PolicyType{container},
     delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename OutputDispatchIteratorT>
-State Ranged<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
+State Ranged<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
   OutputDispatchIteratorT&& output,
   const CaptureRange<stamp_type>& range)
 {
@@ -74,8 +74,8 @@ State Ranged<DispatchT, LockPolicyT, AllocatorT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-State Ranged<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+State Ranged<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
 {
   // Abort early on empty queue
   if (PolicyType::queue_.empty())
@@ -104,8 +104,8 @@ State Ranged<DispatchT, LockPolicyT, AllocatorT>::dry_capture_follower_impl(cons
   }
 }
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-auto Ranged<DispatchT, LockPolicyT, AllocatorT>::find_after_first(const CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+auto Ranged<DispatchT, LockPolicyT, ContainerT>::find_after_first(const CaptureRange<stamp_type>& range) const
 {
   return std::find_if(
     PolicyType::queue_.begin(),
@@ -115,9 +115,9 @@ auto Ranged<DispatchT, LockPolicyT, AllocatorT>::find_after_first(const CaptureR
     });
 }
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
 template <typename QueueIteratorT>
-auto Ranged<DispatchT, LockPolicyT, AllocatorT>::find_before_last(
+auto Ranged<DispatchT, LockPolicyT, ContainerT>::find_before_last(
   const CaptureRange<stamp_type>& range,
   const QueueIteratorT after_first) const
 {
@@ -129,8 +129,8 @@ auto Ranged<DispatchT, LockPolicyT, AllocatorT>::find_before_last(
     });
 }
 
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-void Ranged<DispatchT, LockPolicyT, AllocatorT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+void Ranged<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
 {}
 
 }  // namespace follower

--- a/flow/include/follower/latched.h
+++ b/flow/include/follower/latched.h
@@ -26,7 +26,7 @@ namespace follower
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  *
  * @note Latched won't behave non-deterministically if actual input period (difference between successive
  *       dispatch stamps) is greater than <code>min_period</code>. However, newer data values will not be captured if
@@ -35,8 +35,8 @@ namespace follower
  * @warn Latched may never enter a READY state if data never becomes available. Calling application may need to
  * implement a synchronization timeout behavior
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class Latched : public Follower<Latched<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class Latched : public Follower<Latched<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Data stamp type
@@ -56,14 +56,14 @@ public:
    * @brief Setup constructor
    *
    * @param min_period  minimum expected difference between data stamps
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    *
    * @throw <code>std::invalid_argument</code> if <code>m_after < 1</code>
    */
-  Latched(const offset_type min_period, const AllocatorT& alloc);
+  Latched(const offset_type min_period, const ContainerT& container);
 
 private:
-  using PolicyType = Follower<Latched<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Follower<Latched<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -114,14 +114,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<follower::Latched<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<follower::Latched<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/follower/matched_stamp.h
+++ b/flow/include/follower/matched_stamp.h
@@ -23,11 +23,11 @@ namespace follower
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  captured output container type
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class MatchedStamp : public Follower<MatchedStamp<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class MatchedStamp : public Follower<MatchedStamp<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Data stamp type
@@ -40,12 +40,12 @@ public:
 
   /**
    * @brief Setup constructor
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    */
-  explicit MatchedStamp(const AllocatorT& alloc);
+  explicit MatchedStamp(const ContainerT& container);
 
 private:
-  using PolicyType = Follower<MatchedStamp<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Follower<MatchedStamp<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -89,14 +89,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<follower::MatchedStamp<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<follower::MatchedStamp<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/follower/ranged.h
+++ b/flow/include/follower/ranged.h
@@ -24,10 +24,10 @@ namespace follower
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename AllocatorT = std::allocator<DispatchT>>
-class Ranged : public Follower<Ranged<DispatchT, LockPolicyT, AllocatorT>>
+template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
+class Ranged : public Follower<Ranged<DispatchT, LockPolicyT, ContainerT>>
 {
 public:
   /// Data stamp type
@@ -50,12 +50,12 @@ public:
    * @brief Setup constructor
    *
    * @param delay  the delay with which to capture
-   * @param alloc  dispatch object allocator with some initial state
+   * @param container  dispatch object container (non-default initialization)
    */
-  Ranged(const offset_type& delay, const AllocatorT& alloc);
+  Ranged(const offset_type& delay, const ContainerT& container);
 
 private:
-  using PolicyType = Follower<Ranged<DispatchT, LockPolicyT, AllocatorT>>;
+  using PolicyType = Follower<Ranged<DispatchT, LockPolicyT, ContainerT>>;
   friend PolicyType;
 
   /**
@@ -116,14 +116,14 @@ private:
  * @tparam DispatchT  data dispatch type
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
- * @tparam AllocatorT  <code>DispatchT</code> allocator type
+ * @tparam ContainerT  underlying <code>DispatchT</code> container type
  * @tparam CaptureOutputT  output capture container type
  */
-template <typename DispatchT, typename LockPolicyT, typename AllocatorT>
-struct CaptorTraits<follower::Ranged<DispatchT, LockPolicyT, AllocatorT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+struct CaptorTraits<follower::Ranged<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
 {
-  /// Dispatch object allocation type
-  using DispatchAllocatorType = AllocatorT;
+  /// Underlying dispatch container type
+  using DispatchContainerType = ContainerT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/impl/captor_interface.hpp
+++ b/flow/include/impl/captor_interface.hpp
@@ -21,9 +21,9 @@ template <typename CaptorT> CaptorInterface<CaptorT>::CaptorInterface(const size
 
 
 template <typename CaptorT>
-CaptorInterface<CaptorT>::CaptorInterface(const size_type capacity, const DispatchAllocatorType& alloc) :
+CaptorInterface<CaptorT>::CaptorInterface(const size_type capacity, const DispatchContainerType& container) :
     capacity_{capacity},
-    queue_{alloc}
+    queue_{container}
 {}
 
 

--- a/flow/include/impl/captor_lockable.hpp
+++ b/flow/include/impl/captor_lockable.hpp
@@ -23,8 +23,8 @@ Captor<CaptorT, LockableT>::Captor() : CaptorInterfaceType{0UL}, capturing_{true
 
 
 template <typename CaptorT, typename LockableT>
-Captor<CaptorT, LockableT>::Captor(const DispatchAllocatorType& alloc) :
-    CaptorInterfaceType{0UL, alloc},
+Captor<CaptorT, LockableT>::Captor(const DispatchContainerType& container) :
+    CaptorInterfaceType{0UL, container},
     capturing_{true}
 {}
 

--- a/flow/include/impl/captor_nolock.hpp
+++ b/flow/include/impl/captor_nolock.hpp
@@ -27,8 +27,8 @@ public:
   /// Data dispatch type
   using DispatchType = typename CaptorTraits<CaptorT>::DispatchType;
 
-  /// Data dispatch allocator type
-  using DispatchAllocatorType = typename CaptorTraits<CaptorT>::DispatchAllocatorType;
+  /// Underlying dispatch container type
+  using DispatchContainerType = typename CaptorTraits<CaptorT>::DispatchContainerType;
 
   /// Data stamp type
   using stamp_type = typename CaptorTraits<CaptorT>::stamp_type;
@@ -44,13 +44,13 @@ public:
   Captor() : CaptorInterfaceType{0UL} {}
 
   /**
-   * @brief Dispatch allocator constructor
+   * @brief Dispatch container constructor
    *
-   * @param alloc  allocator object with some initial state
+   * @param container  container object with some initial state
    *
    * @note Initializes data capacity with NO LIMITS on buffer size
    */
-  Captor(const DispatchAllocatorType& alloc) : CaptorInterfaceType{0UL, alloc} {}
+  Captor(const DispatchContainerType& container) : CaptorInterfaceType{0UL, container} {}
 
   /**
    * @brief Destructor

--- a/flow/include/impl/captor_polling.hpp
+++ b/flow/include/impl/captor_polling.hpp
@@ -30,8 +30,8 @@ public:
   /// Data dispatch type
   using DispatchType = typename CaptorTraits<CaptorT>::DispatchType;
 
-  /// Data dispatch allocator type
-  using DispatchAllocatorType = typename CaptorTraits<CaptorT>::DispatchAllocatorType;
+  /// Underlying dispatch container type
+  using DispatchContainerType = typename CaptorTraits<CaptorT>::DispatchContainerType;
 
   /// Data stamp type
   using stamp_type = typename CaptorTraits<CaptorT>::stamp_type;
@@ -47,13 +47,13 @@ public:
   Captor() : CaptorInterfaceType{0UL} {}
 
   /**
-   * @brief Dispatch allocator constructor
+   * @brief Dispatch container constructor
    *
-   * @param alloc  allocator object with some initial state
+   * @param container  container object with some initial state
    *
    * @note Initializes data capacity with NO LIMITS on buffer size
    */
-  Captor(const DispatchAllocatorType& alloc) : CaptorInterfaceType{0UL, alloc} {}
+  Captor(const DispatchContainerType& container) : CaptorInterfaceType{0UL, container} {}
 
   /**
    * @brief Destructor


### PR DESCRIPTION
Switch from allocator template params to container params

- The original idea was to allow users to specify their own memory management
     + so supplying an allocator to DispatchQueue was the way it went
- DispatchQueue was just a wrapper around a deque, and some people might not want to use a deque
- By supplied the whole underlying container, much like std::priority_queue does, the user can specify both
     + data allocation strategy
     + data management
- This change allows people to choose a container that best fits their use case without breaking any interfaces
