### PR TITLE
(master) Add Synchronizer return state for when driver lower bound is violated

### DIFF
--- a/flow/include/captor_state.h
+++ b/flow/include/captor_state.h
@@ -21,6 +21,7 @@ enum class State : int
   PRIMED,  ///< Captor has captured data and its ready
   ABORT,  ///< Captor has requested to abort current capture attempt
   TIMEOUT,  ///< Captor has hit a data-wait timeout
+  ERROR_DRIVER_LOWER_BOUND_EXCEEDED,  ///< Error code used to indicate that driving violated external lower bound
   _N_STATES,  ///< Total number of captor states
 };
 

--- a/flow/include/captor_state_ostream.h
+++ b/flow/include/captor_state_ostream.h
@@ -34,6 +34,8 @@ inline std::ostream& operator<<(std::ostream& os, const State state)
     return os << "ABORT";
   case State::TIMEOUT:
     return os << "TIMEOUT";
+  case State::ERROR_DRIVER_LOWER_BOUND_EXCEEDED:
+    return os << "ERROR_DRIVER_LOWER_BOUND_EXCEEDED";
   default:
     return os;
   }

--- a/flow/include/impl/synchronizer.hpp
+++ b/flow/include/impl/synchronizer.hpp
@@ -106,7 +106,7 @@ public:
     // Set aborted state if driving sequence range violates monotonicity guard
     if (result_->state == State::PRIMED and result_->range.upper_stamp < lower_bound_)
     {
-      result_->state = State::ABORT;
+      result_->state = State::ERROR_DRIVER_LOWER_BOUND_EXCEEDED;
     }
   }
 
@@ -129,7 +129,7 @@ public:
     // Set aborted state if driving sequence range violates monotonicity guard
     if (result_->state == State::PRIMED and result_->range.upper_stamp < lower_bound_)
     {
-      result_->state = State::ABORT;
+      result_->state = State::ERROR_DRIVER_LOWER_BOUND_EXCEEDED;
     }
   }
 

--- a/flow/test/unit/synchronizer.cpp
+++ b/flow/test/unit/synchronizer.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 // Flow
+#include <flow/captor_state_ostream.h>
 #include <flow/drivers.h>
 #include <flow/followers.h>
 #include <flow/synchronizer.h>
@@ -168,7 +169,7 @@ TEST_F(SynchronizerTestSuiteST, CaptureDirectCaptureRange)
 }
 
 
-TEST_F(SynchronizerTestSuiteST, CaptureAbortTimeGuard)
+TEST_F(SynchronizerTestSuiteST, CaptureErrorTimeGuard)
 {
   driver->inject(Dispatch<int, int>{10, 10});
   follower1->inject(Dispatch<int, double>{0, 2.0});
@@ -188,7 +189,7 @@ TEST_F(SynchronizerTestSuiteST, CaptureAbortTimeGuard)
     100 /*guard*/);
 
   ASSERT_FALSE(result);
-  ASSERT_EQ(result.state, State::ABORT);
+  ASSERT_EQ(result.state, State::ERROR_DRIVER_LOWER_BOUND_EXCEEDED);
 
   // Inputs may be captured, but capture is aborted after
   ASSERT_FALSE(driver_output_data.empty());


### PR DESCRIPTION
- Adds ERROR_DRIVER_LOWER_BOUND_EXCEEDED, to replace ABORT code and disambiguate