### PR TITLE
(master) Adds support for queue monitoring/preconditioning facilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,3 +328,7 @@ bazel test ... --test_output=all
 
 Bazel isn't everyone's cup of tea. _cmake build to come later_; earlier contribution welcome.
 
+
+## TODOS
+
+- [ ] Add more documentation for `QueueMonitor`/`QueuePreconditioner` features

--- a/flow/include/captor_state.h
+++ b/flow/include/captor_state.h
@@ -17,11 +17,16 @@ namespace flow
  */
 enum class State : int
 {
+  // basic execution state codes
   RETRY,  ///< Captor should continue waiting for data after prime attempt
   PRIMED,  ///< Captor has captured data and its ready
   ABORT,  ///< Captor has requested to abort current capture attempt
   TIMEOUT,  ///< Captor has hit a data-wait timeout
+
+  // special execution state codes
   ERROR_DRIVER_LOWER_BOUND_EXCEEDED,  ///< Error code used to indicate that driving violated external lower bound
+  SKIP_FRAME_QUEUE_PRECONDITION,  ///< Code use to indicate that the current sync frame is to be skipped, namely when
+                                  ///< when a queue monitor object is used to precondition capture
   _N_STATES,  ///< Total number of captor states
 };
 

--- a/flow/include/captor_state_ostream.h
+++ b/flow/include/captor_state_ostream.h
@@ -36,6 +36,8 @@ inline std::ostream& operator<<(std::ostream& os, const State state)
     return os << "TIMEOUT";
   case State::ERROR_DRIVER_LOWER_BOUND_EXCEEDED:
     return os << "ERROR_DRIVER_LOWER_BOUND_EXCEEDED";
+  case State::SKIP_FRAME_QUEUE_PRECONDITION:
+    return os << "SKIP_FRAME_QUEUE_PRECONDITION";
   default:
     return os;
   }

--- a/flow/include/dispatch_queue.h
+++ b/flow/include/dispatch_queue.h
@@ -34,6 +34,10 @@ public:
   /// Dispatch stamp type
   using stamp_type = typename DispatchTraits<DispatchT>::stamp_type;
 
+  /// Stamp argument type
+  using stamp_const_arg_type =
+    std::conditional_t<sizeof(stamp_type) <= sizeof(stamp_type&), const stamp_type, const stamp_type&>;
+
   /// Dispatch data value type
   using value_type = typename DispatchTraits<DispatchT>::value_type;
 
@@ -70,6 +74,14 @@ public:
   inline bool empty() const;
 
   /**
+   * @brief Returns first iterator to element before stamp
+   *
+   *        Returns <code>end()</code> iterator if
+   * @return <code>const_iterator</code> to first Dispatch resource
+   */
+  inline const_iterator before(stamp_const_arg_type stamp) const;
+
+  /**
    * @brief Returns first iterator to underlying ordered data structure
    * @return <code>const_iterator</code> to first Dispatch resource
    */
@@ -80,6 +92,14 @@ public:
    * @return <code>const_iterator</code> to one element past Dispatch resource
    */
   inline const_iterator end() const { return container_.cend(); }
+
+  /**
+   * @brief Returns first reverse-iterator to element before stamp
+   *
+   *        Returns <code>rend()</code> iterator if
+   * @return <code>const_reverse_iterator</code> to first Dispatch resource
+   */
+  inline const_reverse_iterator rbefore(stamp_const_arg_type stamp) const;
 
   /**
    * @brief Returns first iterator to reversed underlying ordered data structure
@@ -125,14 +145,14 @@ public:
    *
    * @param stamp  lower bound on container sequence stamp
    */
-  inline void remove_before(const stamp_type& t);
+  inline void remove_before(stamp_const_arg_type t);
 
   /**
    * @brief Removes data with stamp older than or equal to some reference sequence stamp
    *
    * @param stamp  lower bound on container sequence stamp
    */
-  inline void remove_at_before(const stamp_type& t);
+  inline void remove_at_before(stamp_const_arg_type t);
 
   /**
    * @brief Removes oldest data until queue has less than or equal to N-elements

--- a/flow/include/driver/chunk.h
+++ b/flow/include/driver/chunk.h
@@ -28,10 +28,14 @@ namespace driver
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
  * @tparam ContainerT  underlying <code>DispatchT</code> container type
- * @tparam CaptureOutputT  captured output container type
+ * @tparam QueueMonitorT  object used to monitor queue state on each insertion
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
-class Chunk : public Driver<Chunk<DispatchT, LockPolicyT, ContainerT>>
+template <
+  typename DispatchT,
+  typename LockPolicyT = NoLock,
+  typename ContainerT = DefaultContainer<DispatchT>,
+  typename QueueMonitorT = DefaultDispatchQueueMonitor>
+class Chunk : public Driver<Chunk<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>
 {
 public:
   /// Integer size type
@@ -44,25 +48,18 @@ public:
    * @brief Configuration constructor
    *
    * @param size  number of elements to batch before becoming ready
+   * @param container  container object with some initial state
    *
    * @throws <code>std::invalid_argument</code> if <code>size == 0</code>
    * @throws <code>std::invalid_argument</code> if <code>CaptureOutputT</code> cannot hold \p size
    */
-  explicit Chunk(const size_type size) noexcept(false);
-
-  /**
-   * @brief Configuration constructor
-   *
-   * @param size  number of elements to batch before becoming ready
-   * @param container  dispatch object container (non-default initialization)
-   *
-   * @throws <code>std::invalid_argument</code> if <code>size == 0</code>
-   * @throws <code>std::invalid_argument</code> if <code>CaptureOutputT</code> cannot hold \p size
-   */
-  explicit Chunk(const size_type size, const ContainerT& container) noexcept(false);
+  explicit Chunk(
+    const size_type size,
+    const ContainerT& container = ContainerT{},
+    const QueueMonitorT& queue_monitor = QueueMonitorT{}) noexcept(false);
 
 private:
-  using PolicyType = Driver<Chunk<DispatchT, LockPolicyT, ContainerT>>;
+  using PolicyType = Driver<Chunk<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>;
   friend PolicyType;
 
   /**
@@ -111,13 +108,17 @@ private:
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
  * @tparam ContainerT  underlying <code>DispatchT</code> container type
- * @tparam CaptureOutputT  output capture container type
+ * @tparam QueueMonitorT  object used to monitor queue state on each insertion
  */
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-struct CaptorTraits<driver::Chunk<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+struct CaptorTraits<driver::Chunk<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>
+    : CaptorTraitsFromDispatch<DispatchT>
 {
   /// Underlying dispatch container type
   using DispatchContainerType = ContainerT;
+
+  /// Queue monitor type
+  using DispatchQueueMonitorType = DefaultDispatchQueueMonitor;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/driver/driver.h
+++ b/flow/include/driver/driver.h
@@ -38,25 +38,26 @@ template <typename PolicyT> struct CaptorTraits<Driver<PolicyT>> : CaptorTraits<
  * @tparam PolicyT  CRTP-derived captor with specialized capture policy
  */
 template <typename PolicyT>
-class Driver : public Captor<Driver<PolicyT>, typename CaptorTraits<PolicyT>::LockPolicyType>
+class Driver
+    : public Captor<Driver<PolicyT>, typename CaptorTraits<PolicyT>::LockPolicyType, DefaultDispatchQueueMonitor>
 {
 public:
   /// Underlying dispatch container type
   using DispatchContainerType = typename CaptorTraits<PolicyT>::DispatchContainerType;
 
+  /// Queue monitor type
+  using DispatchQueueMonitorType = typename CaptorTraits<PolicyT>::DispatchQueueMonitorType;
+
   /// Data stamp type
   using stamp_type = typename CaptorTraits<PolicyT>::stamp_type;
 
   /**
-   * @brief Default constructor
-   */
-  Driver();
-
-  /**
    * @brief Dispatch container constructor
-   * @param container  dispatch object container (non-default initialization)
+   *
+   * @param container  container object with some initial state
+   * @param queue_monitor  queue monitor with some initial state
    */
-  explicit Driver(const DispatchContainerType& container);
+  explicit Driver(const DispatchContainerType& container, const DispatchQueueMonitorType& queue_monitor);
 
 private:
   /**
@@ -93,7 +94,7 @@ private:
 
   FLOW_IMPLEMENT_CRTP_BASE(PolicyT);
 
-  using CaptorType = Captor<Driver, typename CaptorTraits<PolicyT>::LockPolicyType>;
+  using CaptorType = Captor<Driver, typename CaptorTraits<PolicyT>::LockPolicyType, DefaultDispatchQueueMonitor>;
   friend CaptorType;
 
 protected:

--- a/flow/include/driver/impl/batch.hpp
+++ b/flow/include/driver/impl/batch.hpp
@@ -16,25 +16,21 @@ namespace flow
 namespace driver
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Batch<DispatchT, LockPolicyT, ContainerT>::Batch(const size_type size) noexcept(false) : batch_size_{size}
-{
-  validate();
-}
-
-
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Batch<DispatchT, LockPolicyT, ContainerT>::Batch(const size_type size, const ContainerT& container) noexcept(false) :
-    PolicyType{container},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+Batch<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::Batch(
+  const size_type size,
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) noexcept(false) :
+    PolicyType{container, queue_monitor},
     batch_size_{size}
 {
   validate();
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State Batch<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
+State Batch<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_driver_impl(
   OutputDispatchIteratorT output,
   CaptureRange<stamp_type>& range)
 {
@@ -53,8 +49,9 @@ State Batch<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State Batch<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State Batch<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_driver_impl(
+  CaptureRange<stamp_type>& range) const
 {
   if (PolicyType::queue_.size() >= batch_size_)
   {
@@ -72,15 +69,15 @@ State Batch<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(Capture
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Batch<DispatchT, LockPolicyT, ContainerT>::abort_driver_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Batch<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::abort_driver_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort);
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Batch<DispatchT, LockPolicyT, ContainerT>::validate() const noexcept(false)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Batch<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::validate() const noexcept(false)
 {
   if (batch_size_ == 0)
   {

--- a/flow/include/driver/impl/chunk.hpp
+++ b/flow/include/driver/impl/chunk.hpp
@@ -17,25 +17,21 @@ namespace flow
 namespace driver
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Chunk<DispatchT, LockPolicyT, ContainerT>::Chunk(const size_type size) noexcept(false) : PolicyType{}, chunk_size_{size}
-{
-  validate();
-}
-
-
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Chunk<DispatchT, LockPolicyT, ContainerT>::Chunk(const size_type size, const ContainerT& container) noexcept(false) :
-    PolicyType{container},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+Chunk<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::Chunk(
+  const size_type size,
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) noexcept(false) :
+    PolicyType{container, queue_monitor},
     chunk_size_{size}
 {
   validate();
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State Chunk<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
+State Chunk<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_driver_impl(
   OutputDispatchIteratorT output,
   CaptureRange<stamp_type>& range)
 {
@@ -56,8 +52,9 @@ State Chunk<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
   return state;
 }
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State Chunk<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State Chunk<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_driver_impl(
+  CaptureRange<stamp_type>& range) const
 {
   if (PolicyType::queue_.size() >= chunk_size_)
   {
@@ -74,15 +71,15 @@ State Chunk<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(Capture
   }
 }
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Chunk<DispatchT, LockPolicyT, ContainerT>::abort_driver_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Chunk<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::abort_driver_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort);
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Chunk<DispatchT, LockPolicyT, ContainerT>::validate() const noexcept(false)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Chunk<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::validate() const noexcept(false)
 {
   if (chunk_size_ == 0)
   {

--- a/flow/include/driver/impl/driver.hpp
+++ b/flow/include/driver/impl/driver.hpp
@@ -16,10 +16,10 @@
 namespace flow
 {
 
-template <typename PolicyT> Driver<PolicyT>::Driver() : CaptorType{} {}
-
-
-template <typename PolicyT> Driver<PolicyT>::Driver(const DispatchContainerType& container) : CaptorType{container} {}
+template <typename PolicyT>
+Driver<PolicyT>::Driver(const DispatchContainerType& container, const DispatchQueueMonitorType& queue_monitor) :
+    CaptorType{container, queue_monitor}
+{}
 
 
 template <typename PolicyT>

--- a/flow/include/driver/impl/next.hpp
+++ b/flow/include/driver/impl/next.hpp
@@ -12,14 +12,17 @@ namespace flow
 namespace driver
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Next<DispatchT, LockPolicyT, ContainerT>::Next(const ContainerT& container) noexcept(false) : PolicyType{container}
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+Next<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::Next(
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) noexcept(false) :
+    PolicyType{container, queue_monitor}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State Next<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
+State Next<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_driver_impl(
   OutputDispatchIteratorT output,
   CaptureRange<stamp_type>& range)
 {
@@ -35,8 +38,9 @@ State Next<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State Next<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State Next<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_driver_impl(
+  CaptureRange<stamp_type>& range) const
 {
   if (PolicyType::queue_.empty())
   {
@@ -52,8 +56,8 @@ State Next<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(CaptureR
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Next<DispatchT, LockPolicyT, ContainerT>::abort_driver_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Next<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::abort_driver_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort);
 }

--- a/flow/include/driver/impl/throttled.hpp
+++ b/flow/include/driver/impl/throttled.hpp
@@ -15,27 +15,20 @@ namespace flow
 namespace driver
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Throttled<DispatchT, LockPolicyT, ContainerT>::Throttled(const offset_type throttle_period) noexcept(false) :
-    PolicyType{},
-    throttle_period_{throttle_period},
-    previous_stamp_{StampTraits<stamp_type>::min()}
-{}
-
-
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Throttled<DispatchT, LockPolicyT, ContainerT>::Throttled(
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+Throttled<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::Throttled(
   const offset_type throttle_period,
-  const ContainerT& container) noexcept(false) :
-    PolicyType{container},
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) noexcept(false) :
+    PolicyType{container, queue_monitor},
     throttle_period_{throttle_period},
     previous_stamp_{StampTraits<stamp_type>::min()}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State Throttled<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
+State Throttled<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_driver_impl(
   OutputDispatchIteratorT output,
   CaptureRange<stamp_type>& range)
 {
@@ -57,8 +50,9 @@ State Throttled<DispatchT, LockPolicyT, ContainerT>::capture_driver_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State Throttled<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State Throttled<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_driver_impl(
+  CaptureRange<stamp_type>& range) const
 {
   for (const auto& dispatch : PolicyType::queue_)
   {
@@ -75,15 +69,15 @@ State Throttled<DispatchT, LockPolicyT, ContainerT>::dry_capture_driver_impl(Cap
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Throttled<DispatchT, LockPolicyT, ContainerT>::abort_driver_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Throttled<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::abort_driver_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort);
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Throttled<DispatchT, LockPolicyT, ContainerT>::reset_driver_impl()
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Throttled<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::reset_driver_impl()
 {
   previous_stamp_ = StampTraits<stamp_type>::min();
 }

--- a/flow/include/driver/next.h
+++ b/flow/include/driver/next.h
@@ -27,10 +27,14 @@ namespace driver
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
  * @tparam ContainerT  underlying <code>DispatchT</code> container type
- * @tparam CaptureOutputT  captured output container type
+ * @tparam QueueMonitorT  object used to monitor queue state on each insertion
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
-class Next : public Driver<Next<DispatchT, LockPolicyT, ContainerT>>
+template <
+  typename DispatchT,
+  typename LockPolicyT = NoLock,
+  typename ContainerT = DefaultContainer<DispatchT>,
+  typename QueueMonitorT = DefaultDispatchQueueMonitor>
+class Next : public Driver<Next<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>
 {
 public:
   /// Integer size type
@@ -41,17 +45,13 @@ public:
 
   /**
    * @brief Configuration constructor
+   *
+   * @param container  container object with some initial state
    */
-  explicit Next() = default;
-
-  /**
-   * @brief Configuration constructor
-   * @param container  dispatch object container (non-default initialization)
-   */
-  explicit Next(const ContainerT& container);
+  explicit Next(const ContainerT& container = ContainerT{}, const QueueMonitorT& queue_monitor = QueueMonitorT{});
 
 private:
-  using PolicyType = Driver<Next<DispatchT, LockPolicyT, ContainerT>>;
+  using PolicyType = Driver<Next<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>;
   friend PolicyType;
 
   /**
@@ -92,13 +92,17 @@ private:
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
  * @tparam ContainerT  underlying <code>DispatchT</code> container type
- * @tparam CaptureOutputT  output capture container type
+ * @tparam QueueMonitorT  object used to monitor queue state on each insertion
  */
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-struct CaptorTraits<driver::Next<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+struct CaptorTraits<driver::Next<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>
+    : CaptorTraitsFromDispatch<DispatchT>
 {
   /// Underlying dispatch container type
   using DispatchContainerType = ContainerT;
+
+  /// Queue monitor type
+  using DispatchQueueMonitorType = QueueMonitorT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/follower/before.h
+++ b/flow/include/follower/before.h
@@ -25,9 +25,14 @@ namespace follower
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
  * @tparam ContainerT  underlying <code>DispatchT</code> container type
+ * @tparam QueueMonitorT  object used to monitor queue state on each insertion; used to precondition capture
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
-class Before : public Follower<Before<DispatchT, LockPolicyT, ContainerT>>
+template <
+  typename DispatchT,
+  typename LockPolicyT = NoLock,
+  typename ContainerT = DefaultContainer<DispatchT>,
+  typename QueueMonitorT = DefaultDispatchQueueMonitor>
+class Before : public Follower<Before<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>
 {
 public:
   /// Data stamp type
@@ -38,19 +43,18 @@ public:
 
   /**
    * @brief Setup constructor
+   *
    * @param delay  the delay with which to capture
+   * @param container  container object with some initial state
+   * @param queue_monitor  queue monitor with some initial state
    */
-  explicit Before(const offset_type& delay);
-
-  /**
-   * @brief Setup constructor
-   * @param delay  the delay with which to capture
-   * @param container  dispatch object container (non-default initialization)
-   */
-  Before(const offset_type& delay, const ContainerT& container);
+  explicit Before(
+    const offset_type& delay,
+    const ContainerT& container = ContainerT{},
+    const QueueMonitorT& queue_monitor = QueueMonitorT{});
 
 private:
-  using PolicyType = Follower<Before<DispatchT, LockPolicyT, ContainerT>>;
+  using PolicyType = Follower<Before<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>;
   friend PolicyType;
 
   /**
@@ -95,13 +99,17 @@ private:
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
  * @tparam ContainerT  underlying <code>DispatchT</code> container type
- * @tparam CaptureOutputT  output capture container type
+ * @tparam QueueMonitorT queue monitor/capture preconditioning type
  */
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-struct CaptorTraits<follower::Before<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+struct CaptorTraits<follower::Before<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>
+    : CaptorTraitsFromDispatch<DispatchT>
 {
   /// Underlying dispatch container type
   using DispatchContainerType = ContainerT;
+
+  /// Queue monitor/capture preconditioning type
+  using DispatchQueueMonitorType = QueueMonitorT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/follower/closest_before.h
+++ b/flow/include/follower/closest_before.h
@@ -24,14 +24,19 @@ namespace follower
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
  * @tparam ContainerT  underlying <code>DispatchT</code> container type
+ * @tparam QueueMonitorT  object used to monitor queue state on each insertion; used to precondition capture
  *
  * @warn ClosestBefore will behave non-deterministically if actual input period (difference between successive
  *       dispatch stamps) does not match the <code>period</code> argument specified on construction. For example,
  *       if <code>period</code> is too large, than multiple inputs could appear before the driving range, causing
  *       for different data on two or more iterations where the "latest" data was assumed to have been the same
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
-class ClosestBefore : public Follower<ClosestBefore<DispatchT, LockPolicyT, ContainerT>>
+template <
+  typename DispatchT,
+  typename LockPolicyT = NoLock,
+  typename ContainerT = DefaultContainer<DispatchT>,
+  typename QueueMonitorT = DefaultDispatchQueueMonitor>
+class ClosestBefore : public Follower<ClosestBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>
 {
 public:
   /// Data stamp type
@@ -43,22 +48,19 @@ public:
   /**
    * @brief Setup constructor
    *
-   * @param period  expected period between successive data element
-   * @param delay  the delay with which to capture
-   */
-  ClosestBefore(const offset_type& period, const offset_type& delay);
-
-  /**
-   * @brief Setup constructor
-   *
    * @param period  expected half-period between successive data elements
    * @param delay  the delay with which to capture
-   * @param container  dispatch object container (non-default initialization)
+   * @param container  container object with some initial state
+   * @param queue_monitor  queue monitor with some initial state
    */
-  ClosestBefore(const offset_type& period, const offset_type& delay, const ContainerT& container);
+  ClosestBefore(
+    const offset_type& period,
+    const offset_type& delay,
+    const ContainerT& container = ContainerT{},
+    const QueueMonitorT& queue_monitor = QueueMonitorT{});
 
 private:
-  using PolicyType = Follower<ClosestBefore<DispatchT, LockPolicyT, ContainerT>>;
+  using PolicyType = Follower<ClosestBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>;
   friend PolicyType;
 
   /**
@@ -108,13 +110,17 @@ private:
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
  * @tparam ContainerT  underlying <code>DispatchT</code> container type
- * @tparam CaptureOutputT  output capture container type
+ * @tparam QueueMonitorT queue monitor/capture preconditioning type
  */
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-struct CaptorTraits<follower::ClosestBefore<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+struct CaptorTraits<follower::ClosestBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>
+    : CaptorTraitsFromDispatch<DispatchT>
 {
   /// Underlying dispatch container type
   using DispatchContainerType = ContainerT;
+
+  /// Queue monitor/capture preconditioning type
+  using DispatchQueueMonitorType = QueueMonitorT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/follower/follower.h
+++ b/flow/include/follower/follower.h
@@ -38,25 +38,28 @@ template <typename PolicyT> struct CaptorTraits<Follower<PolicyT>> : CaptorTrait
  * @tparam PolicyT  CRTP-derived captor with specialized capture policy
  */
 template <typename PolicyT>
-class Follower : public Captor<Follower<PolicyT>, typename CaptorTraits<PolicyT>::LockPolicyType>
+class Follower : public Captor<
+                   Follower<PolicyT>,
+                   typename CaptorTraits<PolicyT>::LockPolicyType,
+                   typename CaptorTraits<PolicyT>::DispatchQueueMonitorType>
 {
 public:
   /// Underlying dispatch container type
   using DispatchContainerType = typename CaptorTraits<PolicyT>::DispatchContainerType;
 
+  /// Queue monitor/capture preconditioning type
+  using DispatchQueueMonitorType = typename CaptorTraits<PolicyT>::DispatchQueueMonitorType;
+
   /// Data stamp type
   using stamp_type = typename CaptorTraits<PolicyT>::stamp_type;
 
   /**
-   * @brief Timeout specification constructor
+   * @brief Initialization constructor
+   *
+   * @param container  container object with some initial state
+   * @param queue_monitor  queue monitor with some initial state
    */
-  Follower();
-
-  /**
-   * @brief Timeout specification constructor
-   * @param container  dispatch object container (non-default initialization)
-   */
-  explicit Follower(const DispatchContainerType& container);
+  Follower(const DispatchContainerType& container, const DispatchQueueMonitorType& queue_monitor);
 
 private:
   /**
@@ -92,11 +95,15 @@ private:
 
   FLOW_IMPLEMENT_CRTP_BASE(PolicyT);
 
-  using CaptorType = Captor<Follower, typename CaptorTraits<PolicyT>::LockPolicyType>;
+  using CaptorType = Captor<
+    Follower,
+    typename CaptorTraits<PolicyT>::LockPolicyType,
+    typename CaptorTraits<PolicyT>::DispatchQueueMonitorType>;
   friend CaptorType;
 
 protected:
   using CaptorType::queue_;
+  using CaptorType::queue_monitor_;
 };
 
 

--- a/flow/include/follower/impl/any_before.hpp
+++ b/flow/include/follower/impl/any_before.hpp
@@ -18,21 +18,19 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-AnyBefore<DispatchT, LockPolicyT, ContainerT>::AnyBefore(const offset_type& delay) : delay_{delay}
-{}
-
-
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-AnyBefore<DispatchT, LockPolicyT, ContainerT>::AnyBefore(const offset_type& delay, const ContainerT& container) :
-    PolicyType{container},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+AnyBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::AnyBefore(
+  const offset_type& delay,
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) :
+    PolicyType{container, queue_monitor},
     delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State AnyBefore<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
+State AnyBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -52,16 +50,16 @@ State AnyBefore<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State AnyBefore<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State AnyBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_follower_impl(
   const CaptureRange<stamp_type>& range) const
 {
   return State::PRIMED;
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void AnyBefore<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void AnyBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::abort_follower_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort - delay_);
 }

--- a/flow/include/follower/impl/before.hpp
+++ b/flow/include/follower/impl/before.hpp
@@ -18,21 +18,19 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Before<DispatchT, LockPolicyT, ContainerT>::Before(const offset_type& delay) : delay_{delay}
-{}
-
-
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Before<DispatchT, LockPolicyT, ContainerT>::Before(const offset_type& delay, const ContainerT& container) :
-    PolicyType{container},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+Before<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::Before(
+  const offset_type& delay,
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) :
+    PolicyType{container, queue_monitor},
     delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State Before<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
+State Before<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -64,16 +62,17 @@ State Before<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State Before<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State Before<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_follower_impl(
+  const CaptureRange<stamp_type>& range) const
 {
   const stamp_type boundary = range.upper_stamp - delay_;
   return (PolicyType::queue_.empty() or PolicyType::queue_.newest_stamp() < boundary) ? State::RETRY : State::PRIMED;
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Before<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Before<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::abort_follower_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort - delay_);
 }

--- a/flow/include/follower/impl/closest_before.hpp
+++ b/flow/include/follower/impl/closest_before.hpp
@@ -12,28 +12,21 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-ClosestBefore<DispatchT, LockPolicyT, ContainerT>::ClosestBefore(const offset_type& period, const offset_type& delay) :
-    PolicyType{},
-    period_{period},
-    delay_{delay}
-{}
-
-
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-ClosestBefore<DispatchT, LockPolicyT, ContainerT>::ClosestBefore(
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+ClosestBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::ClosestBefore(
   const offset_type& period,
   const offset_type& delay,
-  const ContainerT& container) :
-    PolicyType{container},
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) :
+    PolicyType{container, queue_monitor},
     period_{period},
     delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State ClosestBefore<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
+State ClosestBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -49,8 +42,8 @@ State ClosestBefore<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State ClosestBefore<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State ClosestBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_follower_impl(
   const CaptureRange<stamp_type>& range)
 {
   // The boundary before which messages are valid and after which they are not. Non-inclusive.
@@ -87,8 +80,8 @@ State ClosestBefore<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_im
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void ClosestBefore<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void ClosestBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::abort_follower_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort - delay_ - period_);
 }

--- a/flow/include/follower/impl/count_before.hpp
+++ b/flow/include/follower/impl/count_before.hpp
@@ -17,24 +17,13 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-CountBefore<DispatchT, LockPolicyT, ContainerT>::CountBefore(const size_type count, const offset_type& delay) :
-    count_{count},
-    delay_{delay}
-{
-  if (count_ == 0)
-  {
-    throw std::invalid_argument{"'count' cannot be 0"};
-  }
-}
-
-
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-CountBefore<DispatchT, LockPolicyT, ContainerT>::CountBefore(
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+CountBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::CountBefore(
   const size_type count,
   const offset_type& delay,
-  const ContainerT& container) :
-    PolicyType{container},
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) :
+    PolicyType{container, queue_monitor},
     count_{count},
     delay_{delay}
 {
@@ -45,9 +34,9 @@ CountBefore<DispatchT, LockPolicyT, ContainerT>::CountBefore(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State CountBefore<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
+State CountBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -63,8 +52,9 @@ State CountBefore<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State CountBefore<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State CountBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_follower_impl(
+  const CaptureRange<stamp_type>& range)
 {
   // Retry if queue has no data
   if (PolicyType::queue_.empty())

--- a/flow/include/follower/impl/follower.hpp
+++ b/flow/include/follower/impl/follower.hpp
@@ -16,10 +16,9 @@
 namespace flow
 {
 
-template <typename PolicyT> Follower<PolicyT>::Follower() : CaptorType{} {}
-
-
-template <typename PolicyT> Follower<PolicyT>::Follower(const DispatchContainerType& container) : CaptorType{container}
+template <typename PolicyT>
+Follower<PolicyT>::Follower(const DispatchContainerType& container, const DispatchQueueMonitorType& queue_monitor) :
+    CaptorType{container, queue_monitor}
 {}
 
 
@@ -27,7 +26,14 @@ template <typename PolicyT>
 template <typename OutputDispatchIteratorT>
 State Follower<PolicyT>::capture_policy_impl(OutputDispatchIteratorT&& output, const CaptureRange<stamp_type>& range)
 {
-  return derived()->capture_follower_impl(std::forward<OutputDispatchIteratorT>(output), range);
+  if (CaptorType::queue_monitor_.check(CaptorType::queue_, range))
+  {
+    return derived()->capture_follower_impl(std::forward<OutputDispatchIteratorT>(output), range);
+  }
+  else
+  {
+    return State::SKIP_FRAME_QUEUE_PRECONDITION;
+  }
 }
 
 

--- a/flow/include/follower/impl/latched.hpp
+++ b/flow/include/follower/impl/latched.hpp
@@ -15,23 +15,19 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Latched<DispatchT, LockPolicyT, ContainerT>::Latched(const offset_type min_period) :
-    PolicyType{},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+Latched<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::Latched(
+  const offset_type min_period,
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) :
+    PolicyType{container, queue_monitor},
     min_period_{min_period}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Latched<DispatchT, LockPolicyT, ContainerT>::Latched(const offset_type min_period, const ContainerT& container) :
-    PolicyType{container},
-    min_period_{min_period}
-{}
-
-
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State Latched<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
+State Latched<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -47,8 +43,9 @@ State Latched<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State Latched<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State Latched<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_follower_impl(
+  const CaptureRange<stamp_type>& range)
 {
   if (PolicyType::queue_.empty())
   {
@@ -101,15 +98,15 @@ State Latched<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(con
   return State::PRIMED;
 }
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Latched<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Latched<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::abort_follower_impl(const stamp_type& t_abort)
 {
   // don't remove anything abort
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Latched<DispatchT, LockPolicyT, ContainerT>::reset_follower_impl() noexcept(true)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Latched<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::reset_follower_impl() noexcept(true)
 {
   latched_.reset();
 }

--- a/flow/include/follower/impl/matched_stamp.hpp
+++ b/flow/include/follower/impl/matched_stamp.hpp
@@ -15,14 +15,17 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-MatchedStamp<DispatchT, LockPolicyT, ContainerT>::MatchedStamp(const ContainerT& container) : PolicyType{container}
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+MatchedStamp<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::MatchedStamp(
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) :
+    PolicyType{container, queue_monitor}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State MatchedStamp<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
+State MatchedStamp<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_follower_impl(
   OutputDispatchIteratorT output,
   const CaptureRange<stamp_type>& range)
 {
@@ -38,8 +41,9 @@ State MatchedStamp<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State MatchedStamp<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State MatchedStamp<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_follower_impl(
+  const CaptureRange<stamp_type>& range)
 {
   // Remove all elements before leading time
   PolicyType::queue_.remove_before(range.lower_stamp);
@@ -58,8 +62,8 @@ State MatchedStamp<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_imp
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void MatchedStamp<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void MatchedStamp<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::abort_follower_impl(const stamp_type& t_abort)
 {
   PolicyType::queue_.remove_before(t_abort);
 }

--- a/flow/include/follower/impl/ranged.hpp
+++ b/flow/include/follower/impl/ranged.hpp
@@ -18,21 +18,19 @@ namespace flow
 namespace follower
 {
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Ranged<DispatchT, LockPolicyT, ContainerT>::Ranged(const offset_type& delay) : PolicyType{}, delay_{delay}
-{}
-
-
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-Ranged<DispatchT, LockPolicyT, ContainerT>::Ranged(const offset_type& delay, const ContainerT& container) :
-    PolicyType{container},
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+Ranged<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::Ranged(
+  const offset_type& delay,
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) :
+    PolicyType{container, queue_monitor},
     delay_{delay}
 {}
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename OutputDispatchIteratorT>
-State Ranged<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
+State Ranged<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::capture_follower_impl(
   OutputDispatchIteratorT&& output,
   const CaptureRange<stamp_type>& range)
 {
@@ -74,8 +72,9 @@ State Ranged<DispatchT, LockPolicyT, ContainerT>::capture_follower_impl(
 }
 
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-State Ranged<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(const CaptureRange<stamp_type>& range)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+State Ranged<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::dry_capture_follower_impl(
+  const CaptureRange<stamp_type>& range)
 {
   // Abort early on empty queue
   if (PolicyType::queue_.empty())
@@ -104,8 +103,9 @@ State Ranged<DispatchT, LockPolicyT, ContainerT>::dry_capture_follower_impl(cons
   }
 }
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-auto Ranged<DispatchT, LockPolicyT, ContainerT>::find_after_first(const CaptureRange<stamp_type>& range) const
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+auto Ranged<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::find_after_first(
+  const CaptureRange<stamp_type>& range) const
 {
   return std::find_if(
     PolicyType::queue_.begin(),
@@ -115,9 +115,9 @@ auto Ranged<DispatchT, LockPolicyT, ContainerT>::find_after_first(const CaptureR
     });
 }
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
 template <typename QueueIteratorT>
-auto Ranged<DispatchT, LockPolicyT, ContainerT>::find_before_last(
+auto Ranged<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::find_before_last(
   const CaptureRange<stamp_type>& range,
   const QueueIteratorT after_first) const
 {
@@ -129,8 +129,8 @@ auto Ranged<DispatchT, LockPolicyT, ContainerT>::find_before_last(
     });
 }
 
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-void Ranged<DispatchT, LockPolicyT, ContainerT>::abort_follower_impl(const stamp_type& t_abort)
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+void Ranged<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>::abort_follower_impl(const stamp_type& t_abort)
 {}
 
 }  // namespace follower

--- a/flow/include/follower/matched_stamp.h
+++ b/flow/include/follower/matched_stamp.h
@@ -24,28 +24,31 @@ namespace follower
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
  * @tparam ContainerT  underlying <code>DispatchT</code> container type
- * @tparam CaptureOutputT  captured output container type
+ * @tparam QueueMonitorT  object used to monitor queue state on each insertion; used to precondition capture
  */
-template <typename DispatchT, typename LockPolicyT = NoLock, typename ContainerT = DefaultContainer<DispatchT>>
-class MatchedStamp : public Follower<MatchedStamp<DispatchT, LockPolicyT, ContainerT>>
+template <
+  typename DispatchT,
+  typename LockPolicyT = NoLock,
+  typename ContainerT = DefaultContainer<DispatchT>,
+  typename QueueMonitorT = DefaultDispatchQueueMonitor>
+class MatchedStamp : public Follower<MatchedStamp<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>
 {
 public:
   /// Data stamp type
   using stamp_type = typename CaptorTraits<MatchedStamp>::stamp_type;
 
   /**
-   * @brief Default constructor
-   */
-  MatchedStamp() = default;
-
-  /**
    * @brief Setup constructor
-   * @param container  dispatch object container (non-default initialization)
+   *
+   * @param container  container object with some initial state
+   * @param queue_monitor  queue monitor with some initial state
    */
-  explicit MatchedStamp(const ContainerT& container);
+  explicit MatchedStamp(
+    const ContainerT& container = ContainerT{},
+    const QueueMonitorT& queue_monitor = QueueMonitorT{});
 
 private:
-  using PolicyType = Follower<MatchedStamp<DispatchT, LockPolicyT, ContainerT>>;
+  using PolicyType = Follower<MatchedStamp<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>;
   friend PolicyType;
 
   /**
@@ -90,13 +93,17 @@ private:
  * @tparam LockPolicyT  a BasicLockable (https://en.cppreference.com/w/cpp/named_req/BasicLockable) object or NoLock or
  * PollingLock
  * @tparam ContainerT  underlying <code>DispatchT</code> container type
- * @tparam CaptureOutputT  output capture container type
+ * @tparam QueueMonitorT queue monitor/capture preconditioning type
  */
-template <typename DispatchT, typename LockPolicyT, typename ContainerT>
-struct CaptorTraits<follower::MatchedStamp<DispatchT, LockPolicyT, ContainerT>> : CaptorTraitsFromDispatch<DispatchT>
+template <typename DispatchT, typename LockPolicyT, typename ContainerT, typename QueueMonitorT>
+struct CaptorTraits<follower::MatchedStamp<DispatchT, LockPolicyT, ContainerT, QueueMonitorT>>
+    : CaptorTraitsFromDispatch<DispatchT>
 {
   /// Underlying dispatch container type
   using DispatchContainerType = ContainerT;
+
+  /// Queue monitor/capture preconditioning type
+  using DispatchQueueMonitorType = QueueMonitorT;
 
   /// Thread locking policy type
   using LockPolicyType = LockPolicyT;

--- a/flow/include/impl/captor_interface.hpp
+++ b/flow/include/impl/captor_interface.hpp
@@ -17,13 +17,14 @@
 namespace flow
 {
 
-template <typename CaptorT> CaptorInterface<CaptorT>::CaptorInterface(const size_type capacity) : capacity_{capacity} {}
-
-
 template <typename CaptorT>
-CaptorInterface<CaptorT>::CaptorInterface(const size_type capacity, const DispatchContainerType& container) :
+CaptorInterface<CaptorT>::CaptorInterface(
+  const size_type capacity,
+  const DispatchContainerType& container,
+  const DispatchQueueMonitorType& queue_monitor) :
     capacity_{capacity},
-    queue_{container}
+    queue_{container},
+    queue_monitor_{queue_monitor}
 {}
 
 
@@ -32,6 +33,7 @@ template <typename... InsertArgTs>
 void CaptorInterface<CaptorT>::insert_and_limit(InsertArgTs&&... args)
 {
   queue_.insert(std::forward<InsertArgTs>(args)...);
+
   if (capacity_)
   {
     queue_.shrink_to_fit(capacity_);

--- a/flow/include/impl/captor_nolock.hpp
+++ b/flow/include/impl/captor_nolock.hpp
@@ -21,7 +21,8 @@ namespace flow
  * @copydoc Captor
  * @note No-lock captor implementation meant for polling with <code>Captor::capture</code>.
  */
-template <typename CaptorT> class Captor<CaptorT, NoLock> : public CaptorInterface<Captor<CaptorT, NoLock>>
+template <typename CaptorT, typename QueueMonitorT>
+class Captor<CaptorT, NoLock, QueueMonitorT> : public CaptorInterface<Captor<CaptorT, NoLock, QueueMonitorT>>
 {
 public:
   /// Data dispatch type
@@ -37,20 +38,16 @@ public:
   using size_type = typename CaptorTraits<CaptorT>::size_type;
 
   /**
-   * @brief Default constructor
-   *
-   * @note Initializes data capacity with NO LIMITS on buffer size
-   */
-  Captor() : CaptorInterfaceType{0UL} {}
-
-  /**
    * @brief Dispatch container constructor
    *
    * @param container  container object with some initial state
+   * @param queue_monitor  custom implementation for checking the state of the queue and preconditioning capture
    *
    * @note Initializes data capacity with NO LIMITS on buffer size
    */
-  Captor(const DispatchContainerType& container) : CaptorInterfaceType{0UL, container} {}
+  Captor(const DispatchContainerType& container, const QueueMonitorT& queue_monitor) :
+      CaptorInterfaceType{0UL, container, queue_monitor}
+  {}
 
   /**
    * @brief Destructor
@@ -160,7 +157,7 @@ private:
     }
   }
 
-  using CaptorInterfaceType = CaptorInterface<Captor<CaptorT, NoLock>>;
+  using CaptorInterfaceType = CaptorInterface<Captor<CaptorT, NoLock, QueueMonitorT>>;
   friend CaptorInterfaceType;
 
   FLOW_IMPLEMENT_CRTP_BASE(CaptorT);

--- a/flow/include/impl/captor_polling.hpp
+++ b/flow/include/impl/captor_polling.hpp
@@ -22,9 +22,9 @@ namespace flow
  * @note Implements a simple locking policy using a <code>BasicLockableT</code> which
  *       protects data input/output, meant for polling with <code>Captor::capture</code>.
  */
-template <typename CaptorT, typename BasicLockableT>
-class Captor<CaptorT, PollingLock<BasicLockableT>>
-    : public CaptorInterface<Captor<CaptorT, PollingLock<BasicLockableT>>>
+template <typename CaptorT, typename BasicLockableT, typename QueueMonitorT>
+class Captor<CaptorT, PollingLock<BasicLockableT>, QueueMonitorT>
+    : public CaptorInterface<Captor<CaptorT, PollingLock<BasicLockableT>, QueueMonitorT>>
 {
 public:
   /// Data dispatch type
@@ -40,20 +40,16 @@ public:
   using size_type = typename CaptorTraits<CaptorT>::size_type;
 
   /**
-   * @brief Default constructor
-   *
-   * @note Initializes data capacity with NO LIMITS on buffer size
-   */
-  Captor() : CaptorInterfaceType{0UL} {}
-
-  /**
    * @brief Dispatch container constructor
    *
    * @param container  container object with some initial state
+   * @param queue_monitor  custom implementation for checking the state of the queue and preconditioning capture
    *
    * @note Initializes data capacity with NO LIMITS on buffer size
    */
-  Captor(const DispatchContainerType& container) : CaptorInterfaceType{0UL, container} {}
+  Captor(const DispatchContainerType& container, const QueueMonitorT& queue_monitor) :
+      CaptorInterfaceType{0UL, container, queue_monitor}
+  {}
 
   /**
    * @brief Destructor
@@ -190,7 +186,7 @@ private:
   /// Mutex to protect queue ONLY
   mutable std::mutex queue_mutex_;
 
-  using CaptorInterfaceType = CaptorInterface<Captor<CaptorT, PollingLock<BasicLockableT>>>;
+  using CaptorInterfaceType = CaptorInterface<Captor<CaptorT, PollingLock<BasicLockableT>, QueueMonitorT>>;
   friend CaptorInterfaceType;
 
   FLOW_IMPLEMENT_CRTP_BASE(CaptorT);

--- a/flow/include/impl/dispatch_queue.hpp
+++ b/flow/include/impl/dispatch_queue.hpp
@@ -6,6 +6,7 @@
 #define FLOW_CAPTURE_IMPL_DISPATCH_QUEUE_HPP
 
 // C++ Standard Library
+#include <algorithm>
 #include <iterator>
 
 // Flow
@@ -63,6 +64,25 @@ void DispatchQueue<DispatchT, ContainerT>::insert(DispatchConstructorArgTs&&... 
   }
 }
 
+template <typename DispatchT, typename ContainerT>
+typename DispatchQueue<DispatchT, ContainerT>::const_iterator
+DispatchQueue<DispatchT, ContainerT>::before(stamp_const_arg_type stamp) const
+{
+  const auto after_itr = std::find_if(
+    container_.begin(), container_.end(), [stamp](const DispatchT& dispatch) { return get_stamp(dispatch) >= stamp; });
+
+  return after_itr == this->end() ? after_itr : std::prev(after_itr);
+}
+
+
+template <typename DispatchT, typename ContainerT>
+typename DispatchQueue<DispatchT, ContainerT>::const_reverse_iterator
+DispatchQueue<DispatchT, ContainerT>::rbefore(stamp_const_arg_type stamp) const
+{
+  return std::find_if(
+    container_.rbegin(), container_.rend(), [stamp](const DispatchT& dispatch) { return get_stamp(dispatch) < stamp; });
+}
+
 
 template <typename DispatchT, typename ContainerT> DispatchT DispatchQueue<DispatchT, ContainerT>::pop()
 {
@@ -79,7 +99,7 @@ template <typename DispatchT, typename ContainerT> void DispatchQueue<DispatchT,
 
 
 template <typename DispatchT, typename ContainerT>
-void DispatchQueue<DispatchT, ContainerT>::remove_before(const stamp_type& t)
+void DispatchQueue<DispatchT, ContainerT>::remove_before(stamp_const_arg_type t)
 {
   while (!container_.empty() and get_stamp(container_.front()) < t)
   {
@@ -89,7 +109,7 @@ void DispatchQueue<DispatchT, ContainerT>::remove_before(const stamp_type& t)
 
 
 template <typename DispatchT, typename ContainerT>
-void DispatchQueue<DispatchT, ContainerT>::remove_at_before(const stamp_type& t)
+void DispatchQueue<DispatchT, ContainerT>::remove_at_before(stamp_const_arg_type t)
 {
   while (!container_.empty() and get_stamp(container_.front()) <= t)
   {

--- a/flow/include/impl/synchronizer.hpp
+++ b/flow/include/impl/synchronizer.hpp
@@ -28,7 +28,8 @@ struct ResetHelper
   /// No-op
   template <typename StampT> constexpr void operator()(const CaptureRange<StampT>& range) const {}
 
-  template <typename CaptorT, typename LockPolicyT> inline void operator()(Captor<CaptorT, LockPolicyT>& c)
+  template <typename CaptorT, typename LockPolicyT, typename QueueMonitorT>
+  inline void operator()(Captor<CaptorT, LockPolicyT, QueueMonitorT>& c)
   {
     c.reset();
   }
@@ -62,7 +63,8 @@ public:
   /// No-op
   constexpr void operator()(const CaptureRange<StampT>& range) const {}
 
-  template <typename CaptorT, typename LockPolicyT> inline void operator()(Captor<CaptorT, LockPolicyT>& c)
+  template <typename CaptorT, typename LockPolicyT, typename QueueMonitorT>
+  inline void operator()(Captor<CaptorT, LockPolicyT, QueueMonitorT>& c)
   {
     c.abort(t_abort_);
   }
@@ -108,6 +110,8 @@ public:
     {
       result_->state = State::ERROR_DRIVER_LOWER_BOUND_EXCEEDED;
     }
+
+    c.update_sync_state(result_->state);
   }
 
   template <typename PolicyT, typename OutputIteratorT>
@@ -118,6 +122,8 @@ public:
     {
       result_->state = c.capture(output, result_->range);
     }
+
+    c.update_sync_state(result_->state);
   }
 
   template <typename PolicyT, typename OutputIteratorT>
@@ -131,6 +137,8 @@ public:
     {
       result_->state = State::ERROR_DRIVER_LOWER_BOUND_EXCEEDED;
     }
+
+    c.update_sync_state(result_->state);
   }
 
   template <typename PolicyT, typename OutputIteratorT>
@@ -141,6 +149,8 @@ public:
     {
       result_->state = c.capture(output, result_->range, timeout_);
     }
+
+    c.update_sync_state(result_->state);
   }
 
 private:

--- a/flow/test/unit/dispatch_queue.cpp
+++ b/flow/test/unit/dispatch_queue.cpp
@@ -249,4 +249,53 @@ TEST(DispatchQueue, InsertUnordered)
 }
 
 
+TEST(DispatchQueue, BeforeItrEmpty)
+{
+  using DispatchType = Dispatch<int, int>;
+
+  DispatchQueue<DispatchType> queue;
+
+  ASSERT_EQ(queue.before(6), queue.end());
+}
+
+
+TEST(DispatchQueue, BeforeItr)
+{
+  using DispatchType = Dispatch<int, int>;
+
+  DispatchQueue<DispatchType> queue;
+
+  queue.insert(DispatchType{5, 8});
+  queue.insert(DispatchType{6, 9});
+  queue.insert(DispatchType{7, 10});
+
+  ASSERT_EQ(queue.before(6)->stamp, 5);
+  ASSERT_EQ(queue.before(7)->stamp, 6);
+}
+
+
+TEST(DispatchQueue, ReverseBeforeItrEmpty)
+{
+  using DispatchType = Dispatch<int, int>;
+
+  DispatchQueue<DispatchType> queue;
+
+  ASSERT_EQ(queue.rbefore(6), queue.rend());
+}
+
+
+TEST(DispatchQueue, ReverseBeforeItr)
+{
+  using DispatchType = Dispatch<int, int>;
+
+  DispatchQueue<DispatchType> queue;
+
+  queue.insert(DispatchType{5, 8});
+  queue.insert(DispatchType{6, 9});
+  queue.insert(DispatchType{7, 10});
+
+  ASSERT_EQ(queue.rbefore(6)->stamp, 5);
+  ASSERT_EQ(queue.rbefore(7)->stamp, 6);
+}
+
 #endif  // DOXYGEN_SKIP


### PR DESCRIPTION
- Adds `QueueMonitorT` to associate with Captors
    + For drivers/followers, this object can monitor the state of a queue
    + For followers (only) this can be used to directly control capture
- Adds separate capture state for capture frames skipped due to queue preconditioning checks
- Refactors captor constructors to reduce repetition