### PR TITLE
(master) Update captor queue monitor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,4 +331,4 @@ Bazel isn't everyone's cup of tea. _cmake build to come later_; earlier contribu
 
 ## TODOS
 
-- [ ] Add more documentation for `QueueMonitor`/`QueuePreconditioner` features
+- [ ] Add more documentation for `QueueMonitorT` (queue precondition) features

--- a/flow/include/impl/captor_lockable.hpp
+++ b/flow/include/impl/captor_lockable.hpp
@@ -231,6 +231,16 @@ void Captor<CaptorT, LockableT, QueueMonitorT>::inspect_impl(InpectCallbackT&& i
   }
 }
 
+
+template <typename CaptorT, typename LockableT, typename QueueMonitorT>
+template <typename CaptureRangeT>
+void Captor<CaptorT, LockableT, QueueMonitorT>::update_queue_monitor_impl(CaptureRangeT&& range, const State sync_state)
+{
+  LockableT lock{capture_mutex_};
+  CaptorInterfaceType::queue_monitor_.update(
+    CaptorInterfaceType::queue_, std::forward<CaptureRangeT>(range), sync_state);
+}
+
 }  // namespace flow
 
 #endif  // FLOW_CAPTURE_IMPL_CAPTOR_LOCKABLE_HPP

--- a/flow/include/impl/captor_nolock.hpp
+++ b/flow/include/impl/captor_nolock.hpp
@@ -157,6 +157,15 @@ private:
     }
   }
 
+  /**
+   * @copydoc CaptorInterface::update_queue_monitor
+   */
+  template <typename CaptureRangeT> void update_queue_monitor_impl(CaptureRangeT&& range, const State sync_state)
+  {
+    CaptorInterfaceType::queue_monitor_.update(
+      CaptorInterfaceType::queue_, std::forward<CaptureRangeT>(range), sync_state);
+  }
+
   using CaptorInterfaceType = CaptorInterface<Captor<CaptorT, NoLock, QueueMonitorT>>;
   friend CaptorInterfaceType;
 

--- a/flow/include/impl/captor_polling.hpp
+++ b/flow/include/impl/captor_polling.hpp
@@ -183,6 +183,16 @@ private:
     }
   }
 
+  /**
+   * @copydoc CaptorInterface::update_monitor
+   */
+  template <typename CaptureRangeT> void update_queue_monitor_impl(CaptureRangeT&& range, const State sync_state)
+  {
+    BasicLockableT lock{queue_mutex_};
+    CaptorInterfaceType::queue_monitor_.update(
+      CaptorInterfaceType::queue_, std::forward<CaptureRangeT>(range), sync_state);
+  }
+
   /// Mutex to protect queue ONLY
   mutable std::mutex queue_mutex_;
 

--- a/flow/include/impl/synchronizer.hpp
+++ b/flow/include/impl/synchronizer.hpp
@@ -111,7 +111,7 @@ public:
       result_->state = State::ERROR_DRIVER_LOWER_BOUND_EXCEEDED;
     }
 
-    c.update_sync_state(result_->state);
+    c.update_queue_monitor(result_->range, result_->state);
   }
 
   template <typename PolicyT, typename OutputIteratorT>
@@ -123,7 +123,7 @@ public:
       result_->state = c.capture(output, result_->range);
     }
 
-    c.update_sync_state(result_->state);
+    c.update_queue_monitor(result_->range, result_->state);
   }
 
   template <typename PolicyT, typename OutputIteratorT>
@@ -138,7 +138,7 @@ public:
       result_->state = State::ERROR_DRIVER_LOWER_BOUND_EXCEEDED;
     }
 
-    c.update_sync_state(result_->state);
+    c.update_queue_monitor(result_->range, result_->state);
   }
 
   template <typename PolicyT, typename OutputIteratorT>
@@ -150,7 +150,7 @@ public:
       result_->state = c.capture(output, result_->range, timeout_);
     }
 
-    c.update_sync_state(result_->state);
+    c.update_queue_monitor(result_->range, result_->state);
   }
 
 private:


### PR DESCRIPTION
- Make these calls thread safe when called from NoLock and Polling captors (protect the queue)
- Pass queue and capture range to Monitor::update